### PR TITLE
feat(flutter_tvos): release 1.0.3 with WidgetsFlutterBinding init

### DIFF
--- a/packages/flutter_tvos/CHANGELOG.md
+++ b/packages/flutter_tvos/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.3
+
+- Example: call `WidgetsFlutterBinding.ensureInitialized()` before `TvRemoteController.instance.init()` so the Flutter binding is ready when the platform channel attaches.
+- pubspec: added `issue_tracker` link so GitHub issues surface on pub.dev.
+
 ## 1.0.2
 
 - Removed the `runTvApp` helper from the public API; apps should use normal `runApp`.

--- a/packages/flutter_tvos/README.md
+++ b/packages/flutter_tvos/README.md
@@ -18,7 +18,7 @@ Add `flutter_tvos` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_tvos: ^1.0.2
+  flutter_tvos: ^1.0.3
 ```
 
 ## Usage

--- a/packages/flutter_tvos/example/lib/main.dart
+++ b/packages/flutter_tvos/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_tvos/flutter_tvos.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   TvRemoteController.instance.init();
   runApp(const FlutterTvosExampleApp());
 }

--- a/packages/flutter_tvos/pubspec.yaml
+++ b/packages/flutter_tvos/pubspec.yaml
@@ -1,8 +1,9 @@
 name: flutter_tvos
 description: Platform detection and utilities for Flutter apps running on Apple TV (tvOS). Provides runtime checks for tvOS, device info, and capability queries.
-version: 1.0.2
+version: 1.0.3
 homepage: https://fluttertv.dev
 repository: https://github.com/fluttertv/flutter-tvos
+issue_tracker: https://github.com/fluttertv/flutter-tvos/issues
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
- Example main.dart calls WidgetsFlutterBinding.ensureInitialized() before TvRemoteController.instance.init()
- Bump pubspec version to 1.0.3
- Add issue_tracker link to surface GitHub issues on pub.dev
- Update README to reference ^1.0.3