### PR TITLE
fix(tvos_plugins): preserve existing .flutter-plugins-dependencies

### DIFF
--- a/lib/tvos_plugins.dart
+++ b/lib/tvos_plugins.dart
@@ -300,11 +300,37 @@ Future<void> ensureReadyForTvosTooling(FlutterProject project) async {
 
   // Tightly-typed inner list lets us avoid dynamic dispatch on `.add(...)`.
   final tvosPluginEntries = <Map<String, dynamic>>[];
-  final dependenciesJson = <String, dynamic>{
+
+  // CRITICAL: preserve the existing `.flutter-plugins-dependencies` rather
+  // than overwriting it. Stock `flutter pub get` writes ios/android/...
+  // plugin lists AND the `dependencyGraph` array we need for later
+  // `_discoverTvosPlugins` calls (e.g. from `writeTvosDartPluginRegistrant`
+  // during the build pipeline). Wiping `dependencyGraph: []` here caused
+  // every federated tvOS plugin with `dartPluginClass:` to silently
+  // disappear from the registrant — producing runtime
+  // `MissingPluginException` and `Bad state: <X>Platform.instance must
+  // be set` errors. See bug investigation 2026-05-26.
+  var dependenciesJson = <String, dynamic>{
     'info': 'This is a generated file; do not edit or check into version control.',
-    'plugins': <String, dynamic>{'tvos': tvosPluginEntries},
+    'plugins': <String, dynamic>{},
     'dependencyGraph': <dynamic>[],
   };
+  final File depsFile = project.flutterPluginsDependenciesFile;
+  if (depsFile.existsSync()) {
+    try {
+      dependenciesJson = json.decode(depsFile.readAsStringSync()) as Map<String, dynamic>;
+    } on FormatException {
+      // Malformed file — fall back to a fresh skeleton (defined above).
+    } on FileSystemException {
+      // File disappeared between existsSync() and read — same fallback.
+    }
+  }
+  // Ensure `plugins` exists and graft the tvOS list onto it. iOS / Android
+  // / etc. entries that stock pub get wrote stay intact.
+  final pluginsMap =
+      (dependenciesJson['plugins'] as Map<String, dynamic>?) ?? <String, dynamic>{};
+  pluginsMap['tvos'] = tvosPluginEntries;
+  dependenciesJson['plugins'] = pluginsMap;
 
   final pluginsBuffer = StringBuffer();
 

--- a/lib/tvos_plugins.dart
+++ b/lib/tvos_plugins.dart
@@ -102,14 +102,23 @@ List<_DependencyPluginYaml> _walkPluginDependencies(FlutterProject project) {
   }
   Map<String, dynamic> depsJson;
   try {
-    depsJson = json.decode(depsFile.readAsStringSync()) as Map<String, dynamic>;
+    final decoded = json.decode(depsFile.readAsStringSync());
+    if (decoded is! Map<String, dynamic>) {
+      // Root JSON is valid but not an object (e.g. `[]`, `null`, a
+      // bare number). A blind `as Map` cast would throw `TypeError`
+      // outside the try/catch — degrade silently here the same way
+      // we do for malformed JSON.
+      return out;
+    }
+    depsJson = decoded;
   } on FormatException {
     return out; // Malformed JSON — treat as no plugins.
   } on FileSystemException {
     return out; // File disappeared between existsSync() and read.
   }
+  final rawGraph = depsJson['dependencyGraph'];
   final List<dynamic> depGraph =
-      (depsJson['dependencyGraph'] as List<dynamic>?) ?? <dynamic>[];
+      rawGraph is List<dynamic> ? rawGraph : <dynamic>[];
 
   // Build a name→path map from .dart_tool/package_config.json.
   final packagePaths = <String, String>{};
@@ -318,17 +327,38 @@ Future<void> ensureReadyForTvosTooling(FlutterProject project) async {
   final File depsFile = project.flutterPluginsDependenciesFile;
   if (depsFile.existsSync()) {
     try {
-      dependenciesJson = json.decode(depsFile.readAsStringSync()) as Map<String, dynamic>;
-    } on FormatException {
-      // Malformed file — fall back to a fresh skeleton (defined above).
-    } on FileSystemException {
-      // File disappeared between existsSync() and read — same fallback.
+      final decoded = json.decode(depsFile.readAsStringSync());
+      if (decoded is Map<String, dynamic>) {
+        dependenciesJson = decoded;
+      } else {
+        // Valid JSON whose root isn't an object (e.g. `[]`, `null`,
+        // a bare number). A blind `as Map<String, dynamic>` would
+        // throw `TypeError` and crash the build — fall back to the
+        // fresh skeleton instead, and surface a warning so the
+        // bad file isn't silently masked.
+        globals.logger.printWarning(
+          '.flutter-plugins-dependencies is not a JSON object; regenerating from scratch.',
+        );
+      }
+    } on FormatException catch (e) {
+      globals.logger.printWarning(
+        '.flutter-plugins-dependencies contains malformed JSON ($e); regenerating from scratch.',
+      );
+    } on FileSystemException catch (e) {
+      globals.logger.printWarning(
+        '.flutter-plugins-dependencies disappeared before it could be read ($e); regenerating from scratch.',
+      );
     }
   }
   // Ensure `plugins` exists and graft the tvOS list onto it. iOS / Android
-  // / etc. entries that stock pub get wrote stay intact.
-  final pluginsMap =
-      (dependenciesJson['plugins'] as Map<String, dynamic>?) ?? <String, dynamic>{};
+  // / etc. entries that stock pub get wrote stay intact. Use a runtime
+  // type check rather than `as Map<String, dynamic>?` so a wrong-shaped
+  // value (e.g. `"plugins": []`) falls back to an empty map instead of
+  // throwing `TypeError` outside the try/catch above.
+  final rawPlugins = dependenciesJson['plugins'];
+  final pluginsMap = rawPlugins is Map<String, dynamic>
+      ? rawPlugins
+      : <String, dynamic>{};
   pluginsMap['tvos'] = tvosPluginEntries;
   dependenciesJson['plugins'] = pluginsMap;
 

--- a/test/general/tvos_plugins_test.dart
+++ b/test/general/tvos_plugins_test.dart
@@ -600,5 +600,194 @@ flutter:
         Logger: () => logger,
       },
     );
+
+    // Regression test for the bug where ensureReadyForTvosTooling was
+    // wiping `.flutter-plugins-dependencies` — replacing the file
+    // produced by stock `flutter pub get` with one that contained only
+    // the `tvos` key and an empty `dependencyGraph`. That broke every
+    // later `_discoverTvosPlugins` call (notably during the build
+    // pipeline), making every federated tvOS plugin with
+    // `dartPluginClass:` silently drop from `dart_plugin_registrant.dart`.
+    testUsingContext(
+      'preserves dependencyGraph and existing platform plugin keys',
+      () async {
+        final Directory projectDir = fileSystem.directory('/p')..createSync();
+        projectDir.childDirectory('tvos').createSync();
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: app\n');
+
+        // Simulate exactly what stock `flutter pub get` writes: a
+        // populated `dependencyGraph` (used by `_discoverTvosPlugins`
+        // to walk the project's deps) and existing `ios`/`android`
+        // plugin lists that must NOT be lost.
+        projectDir.childFile('.flutter-plugins-dependencies').writeAsStringSync(
+          json.encode(<String, dynamic>{
+            'info': 'This is a generated file; do not edit or check into version control.',
+            'plugins': <String, dynamic>{
+              'ios': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'name': 'shared_preferences_foundation',
+                  'path': '/pubcache/shared_preferences_foundation',
+                  'dependencies': <String>[],
+                },
+              ],
+              'android': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'name': 'shared_preferences_android',
+                  'path': '/pubcache/shared_preferences_android',
+                  'dependencies': <String>[],
+                },
+              ],
+            },
+            'dependencyGraph': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'name': 'shared_preferences',
+                'dependencies': <String>['shared_preferences_foundation'],
+              },
+              <String, dynamic>{
+                'name': 'shared_preferences_foundation',
+                'dependencies': <String>[],
+              },
+              <String, dynamic>{
+                'name': 'shared_preferences_android',
+                'dependencies': <String>[],
+              },
+            ],
+            'date_created': '2026-05-26 00:00:00.000',
+            'version': '3.44.0',
+            'swift_package_manager_enabled': false,
+          }),
+        );
+
+        // Minimal `.dart_tool/package_config.json` — required by
+        // `_discoverTvosPlugins`'s name→path resolution step, but no
+        // tvOS plugins are present so the resolved tvos list is `[]`.
+        fileSystem.directory('/p/.dart_tool').createSync();
+        fileSystem
+            .file('/p/.dart_tool/package_config.json')
+            .writeAsStringSync(json.encode(<String, dynamic>{'packages': <dynamic>[]}));
+
+        final FlutterProject project = FlutterProject.fromDirectory(projectDir);
+        await ensureReadyForTvosTooling(project);
+
+        // Re-read what was written back to disk.
+        final after = json.decode(
+          projectDir.childFile('.flutter-plugins-dependencies').readAsStringSync(),
+        ) as Map<String, dynamic>;
+
+        // dependencyGraph must survive untouched.
+        expect(
+          after['dependencyGraph'],
+          isA<List<dynamic>>().having((l) => l.length, 'length', 3),
+          reason: 'dependencyGraph from stock pub get must NOT be replaced with []',
+        );
+
+        // ios + android plugin lists must survive intact.
+        final pluginsAfter = after['plugins'] as Map<String, dynamic>;
+        expect(
+          pluginsAfter.containsKey('ios'),
+          isTrue,
+          reason: 'plugins.ios entries must NOT be wiped',
+        );
+        expect(
+          pluginsAfter.containsKey('android'),
+          isTrue,
+          reason: 'plugins.android entries must NOT be wiped',
+        );
+        expect(
+          (pluginsAfter['ios'] as List<dynamic>).first as Map<String, dynamic>,
+          containsPair('name', 'shared_preferences_foundation'),
+        );
+
+        // The new `tvos` key must be added alongside (empty in this
+        // test because no tvOS plugin is in deps), not as a replacement.
+        expect(pluginsAfter.containsKey('tvos'), isTrue);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    // The two read-time defences flagged in code review on PR #15:
+    // a `.flutter-plugins-dependencies` whose root JSON isn't an
+    // object (e.g. `[]`, `null`, a bare number) must not crash the
+    // build with a `TypeError` — we fall back to a fresh skeleton
+    // and warn instead.
+    testUsingContext(
+      'falls back when .flutter-plugins-dependencies root is not an object',
+      () async {
+        final Directory projectDir = fileSystem.directory('/p')..createSync();
+        projectDir.childDirectory('tvos').createSync();
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: app\n');
+        // Valid JSON, but the root is an array — would crash on
+        // a blind `as Map<String, dynamic>` cast.
+        projectDir
+            .childFile('.flutter-plugins-dependencies')
+            .writeAsStringSync('[]');
+        fileSystem.directory('/p/.dart_tool').createSync();
+        fileSystem
+            .file('/p/.dart_tool/package_config.json')
+            .writeAsStringSync(json.encode(<String, dynamic>{'packages': <dynamic>[]}));
+
+        final FlutterProject project = FlutterProject.fromDirectory(projectDir);
+
+        // Should NOT throw — should warn and regenerate from skeleton.
+        await ensureReadyForTvosTooling(project);
+
+        expect(
+          logger.warningText,
+          contains('.flutter-plugins-dependencies is not a JSON object'),
+        );
+        // The fallback skeleton was written, with the `tvos` key grafted on.
+        final after = json.decode(
+          projectDir.childFile('.flutter-plugins-dependencies').readAsStringSync(),
+        ) as Map<String, dynamic>;
+        expect((after['plugins'] as Map<String, dynamic>).containsKey('tvos'), isTrue);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'falls back when plugins key exists but is not a map',
+      () async {
+        final Directory projectDir = fileSystem.directory('/p')..createSync();
+        projectDir.childDirectory('tvos').createSync();
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: app\n');
+        // Root IS a map this time, but `plugins` is the wrong shape
+        // (an array). The cast `as Map<String, dynamic>?` would
+        // throw `TypeError` outside the try/catch; the type-check
+        // pattern degrades gracefully instead.
+        projectDir.childFile('.flutter-plugins-dependencies').writeAsStringSync(
+          json.encode(<String, dynamic>{
+            'plugins': <dynamic>[], // wrong: should be a map
+            'dependencyGraph': <dynamic>[],
+          }),
+        );
+        fileSystem.directory('/p/.dart_tool').createSync();
+        fileSystem
+            .file('/p/.dart_tool/package_config.json')
+            .writeAsStringSync(json.encode(<String, dynamic>{'packages': <dynamic>[]}));
+
+        final FlutterProject project = FlutterProject.fromDirectory(projectDir);
+        await ensureReadyForTvosTooling(project);
+
+        final after = json.decode(
+          projectDir.childFile('.flutter-plugins-dependencies').readAsStringSync(),
+        ) as Map<String, dynamic>;
+        // Wrong-shaped plugins replaced with a fresh map containing tvos.
+        expect(after['plugins'], isA<Map<String, dynamic>>());
+        expect((after['plugins'] as Map<String, dynamic>).containsKey('tvos'), isTrue);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Fixes a regression in `ensureReadyForTvosTooling` where the CLI was wiping `.flutter-plugins-dependencies` instead of grafting tvOS entries onto it. Every federated tvOS plugin with `dartPluginClass:` was silently dropped from the generated `dart_plugin_registrant.dart`, breaking the federated plugin chain at runtime.

## The bug

`ensureReadyForTvosTooling` constructed a fresh `dependenciesJson` and wrote it over the file that stock `flutter pub get` had just populated:

```dart
final dependenciesJson = <String, dynamic>{
  'info': '...',
  'plugins': <String, dynamic>{'tvos': tvosPluginEntries},   // only `tvos` key
  'dependencyGraph': <dynamic>[],                            // reset to empty!
};
```

That wiped the `ios` / `android` / `macos` / `web` plugin lists **and** the `dependencyGraph` written by stock pub get.

Later in the build pipeline, `writeTvosDartPluginRegistrant` calls `_discoverTvosPlugins` again, which walks `dependencyGraph` to find tvOS plugins. With the graph emptied, it finds nothing → writes an empty `dart_plugin_registrant.dart` → federated plugins never call their `registerWith()`.

## Visible symptoms

| Plugin | Pre-fix runtime error |
|---|---|
| `shared_preferences_tvos` | `Bad state: The SharedPreferencesAsyncPlatform instance must be set.` |
| `video_player_tvos` | `UnimplementedError` on `VideoPlayerPlatform.instance.create(...)` |
| `path_provider_tvos` | `MissingPluginException(...path_provider...)` (transitive via other plugins) |
| `audioplayers_tvos` | `MissingPluginException(...xyz.luan/audioplayers.global...)` |
| `flutter_secure_storage_tvos` | plugin never registered → test runner hung |

Each of these declares a `dartPluginClass:` (e.g. `SharedPreferencesFoundation`, `AVFoundationVideoPlayer`, `PathProviderTvos`). Plugins that only declare `pluginClass:` (no `dartPluginClass:`) were unaffected because their registration goes through the Swift `GeneratedPluginRegistrant.swift` path, which has a separate generator that doesn't depend on `dependencyGraph`.

## The fix

Read the existing `.flutter-plugins-dependencies` (falling back to a fresh skeleton if absent or malformed) and only **graft** the tvOS plugin entries onto the `plugins` map. `ios` / `android` / `macos` / `web` entries and the `dependencyGraph` written by stock pub get are preserved.

```dart
var dependenciesJson = <String, dynamic>{
  'info': '...',
  'plugins': <String, dynamic>{},
  'dependencyGraph': <dynamic>[],
};
final File depsFile = project.flutterPluginsDependenciesFile;
if (depsFile.existsSync()) {
  try {
    dependenciesJson = json.decode(depsFile.readAsStringSync()) as Map<String, dynamic>;
  } on FormatException { /* fall back */ }
  on FileSystemException { /* fall back */ }
}
final pluginsMap = (dependenciesJson['plugins'] as Map<String, dynamic>?) ?? <String, dynamic>{};
pluginsMap['tvos'] = tvosPluginEntries;
dependenciesJson['plugins'] = pluginsMap;
```

## Scope / cross-platform safety

`ensureReadyForTvosTooling` early-returns on line 280 if no `tvos/` directory exists:

```dart
if (!tvosDir.existsSync()) {
  return;
}
```

So projects without a tvOS target (pure iOS / Android / web / macOS / Linux / Windows) hit the early return and see zero behavioural change. The fix is strictly additive for tvOS projects — it preserves data that was previously being thrown away.

## Test plan

Tested against `fluttertv/plugins` integration suite (11 plugins) with Flutter 3.44.0:

| | Before fix | After fix |
|---|---|---|
| Unit tests | 11/11 pass | 11/11 pass |
| Integration pass | 5 | **7** |
| Integration fail | 4 (registrant errors) | 2 (real plugin bugs) |
| Wall time | hung / 24 min | **14 min** |

Newly passing integration: `flutter_secure_storage_tvos`, `video_player_tvos`.

Massively improved (failures now visible as real plugin bugs rather than masked by registration errors):
- `shared_preferences_tvos`: was `+63 -23` → now `+85 -1`
- `audioplayers_tvos`: was hung at `+2 -40` → now `+53 -1`

The 2 remaining failures are real plugin logic bugs unrelated to this fix (a migration tool ordering bug in shared_preferences and one audioplayers test).

## Related

Pairs with [`fluttertv/plugins@48c967e`](https://github.com/fluttertv/plugins/commit/48c967e) which untracks the stale empty `GeneratedPluginRegistrant.swift` stubs from each plugin's example app. Together these two commits fully restore federated tvOS plugin registration on Flutter 3.44.