### PR TITLE
fix(build): honour --obfuscate and --split-debug-info in tvOS AOT builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ versions match v1.1.0.
   `App` binary kept readable Dart symbols and the split-debug-info
   directory stayed empty. The gen_snapshot invocation now forwards
   `--obfuscate`, the `--dwarf-stack-traces` / `--resolve-dwarf-paths` /
-  `--save-debugging-info=<dir>/app.ios-arm64.symbols` trio, and any
+  `--save-debugging-info=<dir>/app.tvos-arm64.symbols` trio, and any
   `--extra-gen-snapshot-options`, matching upstream
   `AOTSnapshotter.build` (issue #10).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to flutter-tvos will be documented here.
 
+## [1.1.1] — 2026-05-28
+
+Patch release. No Flutter SDK or engine-artefact change — pinned
+versions match v1.1.0.
+
+### Fixed
+- `--obfuscate` and `--split-debug-info` are now honoured by
+  release/profile (AOT) builds. The tvOS AOT step runs `gen_snapshot`
+  directly (rather than going through upstream `AOTSnapshotter`), and
+  previously dropped these flags entirely — the build succeeded but the
+  `App` binary kept readable Dart symbols and the split-debug-info
+  directory stayed empty. The gen_snapshot invocation now forwards
+  `--obfuscate`, the `--dwarf-stack-traces` / `--resolve-dwarf-paths` /
+  `--save-debugging-info=<dir>/app.ios-arm64.symbols` trio, and any
+  `--extra-gen-snapshot-options`, matching upstream
+  `AOTSnapshotter.build` (issue #10).
+
 ## [1.1.0] — 2026-05-24
 
 Minor release — the "porter release". Adds the entire

--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/build_system/targets/common.dart';
 import 'package:flutter_tools/src/build_system/targets/localizations.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
+import 'package:meta/meta.dart';
 
 import '../tvos_artifacts.dart';
 import '../tvos_build_info.dart';
@@ -706,14 +707,22 @@ class NativeTvosBundle extends Target {
 
     final String assemblyPath = globals.fs.path.join(aotDir.path, 'snapshot_assembly.S');
 
+    // The --split-debug-info directory must exist before gen_snapshot writes to it.
+    final String? splitDebugInfo = environment.defines[kSplitDebugInfo];
+    if (splitDebugInfo != null && splitDebugInfo.isNotEmpty) {
+      globals.fs.directory(splitDebugInfo).createSync(recursive: true);
+    }
+
     // Run gen_snapshot to produce assembly
-    final ProcessResult genSnapshotResult = await globals.processManager.run(<String>[
-      genSnapshotPath,
-      '--deterministic',
-      '--snapshot_kind=app-aot-assembly',
-      '--assembly=$assemblyPath',
-      kernelSnapshot.path,
-    ]);
+    final ProcessResult genSnapshotResult = await globals.processManager.run(
+      tvosGenSnapshotArgs(
+        fileSystem: globals.fs,
+        genSnapshotPath: genSnapshotPath,
+        assemblyPath: assemblyPath,
+        kernelSnapshotPath: kernelSnapshot.path,
+        defines: environment.defines,
+      ),
+    );
 
     if (genSnapshotResult.exitCode != 0) {
       globals.logger.printError('gen_snapshot failed:');
@@ -808,6 +817,47 @@ class NativeTvosBundle extends Target {
         );
 
     globals.logger.printTrace('AOT compilation complete: ${appFramework.path}');
+  }
+
+  /// Builds the gen_snapshot command line for the tvOS AOT assembly step.
+  ///
+  /// Forwards obfuscation / split-debug-info / extra gen_snapshot options from
+  /// the build [defines]. Without this, `--obfuscate` and `--split-debug-info`
+  /// parse at the command level but never reach gen_snapshot, so they silently
+  /// no-op. Mirrors `AOTSnapshotter.build` in
+  /// `flutter_tools/lib/src/base/build.dart`.
+  @visibleForTesting
+  static List<String> tvosGenSnapshotArgs({
+    required FileSystem fileSystem,
+    required String genSnapshotPath,
+    required String assemblyPath,
+    required String kernelSnapshotPath,
+    required Map<String, String> defines,
+  }) {
+    final dartObfuscation = defines[kDartObfuscation] == 'true';
+    final String? splitDebugInfo = defines[kSplitDebugInfo];
+    final bool shouldSplitDebugInfo = splitDebugInfo != null && splitDebugInfo.isNotEmpty;
+    final List<String> extraGenSnapshotOptions = decodeCommaSeparated(
+      defines,
+      kExtraGenSnapshotOptions,
+    );
+    final String? saveDebuggingInfoArg = shouldSplitDebugInfo
+        ? '--save-debugging-info=${fileSystem.path.join(splitDebugInfo, 'app.ios-arm64.symbols')}'
+        : null;
+    return <String>[
+      genSnapshotPath,
+      '--deterministic',
+      '--snapshot_kind=app-aot-assembly',
+      '--assembly=$assemblyPath',
+      ...extraGenSnapshotOptions,
+      if (shouldSplitDebugInfo) ...<String>[
+        '--dwarf-stack-traces',
+        '--resolve-dwarf-paths',
+        saveDebuggingInfoArg!,
+      ],
+      if (dartObfuscation) '--obfuscate',
+      kernelSnapshotPath,
+    ];
   }
 
   /// Returns the SDK path for the given SDK name.

--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -842,7 +842,7 @@ class NativeTvosBundle extends Target {
       kExtraGenSnapshotOptions,
     );
     final String? saveDebuggingInfoArg = shouldSplitDebugInfo
-        ? '--save-debugging-info=${fileSystem.path.join(splitDebugInfo, 'app.ios-arm64.symbols')}'
+        ? '--save-debugging-info=${fileSystem.path.join(splitDebugInfo, 'app.tvos-arm64.symbols')}'
         : null;
     return <String>[
       genSnapshotPath,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_tvos
 description: Flutter CLI tool for building and running Flutter apps on Apple TV (tvOS). A custom embedder wrapping Flutter SDK with tvOS-specific build targets, device management, and plugin support.
-version: 1.1.0
+version: 1.1.1
 homepage: https://fluttertv.dev
 repository: https://github.com/fluttertv/flutter-tvos
 publish_to: "none"

--- a/test/general/tvos_aot_snapshot_test.dart
+++ b/test/general/tvos_aot_snapshot_test.dart
@@ -1,0 +1,94 @@
+// Copyright 2026 The FlutterTV Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tvos/build_targets/application.dart';
+
+import '../src/common.dart';
+
+void main() {
+  late MemoryFileSystem fileSystem;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+  });
+
+  List<String> argsFor(Map<String, String> defines) {
+    return NativeTvosBundle.tvosGenSnapshotArgs(
+      fileSystem: fileSystem,
+      genSnapshotPath: '/engine/gen_snapshot',
+      assemblyPath: '/out/aot/snapshot_assembly.S',
+      kernelSnapshotPath: '/out/app.dill',
+      defines: defines,
+    );
+  }
+
+  testWithoutContext('always emits the base assembly invocation with kernel last', () {
+    final List<String> args = argsFor(<String, String>{});
+    expect(args.first, '/engine/gen_snapshot');
+    expect(
+      args,
+      containsAllInOrder(<String>[
+        '--snapshot_kind=app-aot-assembly',
+        '--assembly=/out/aot/snapshot_assembly.S',
+      ]),
+    );
+    expect(args.last, '/out/app.dill');
+  });
+
+  testWithoutContext('omits --obfuscate and debug flags when defines are absent', () {
+    final List<String> args = argsFor(<String, String>{});
+    expect(args, isNot(contains('--obfuscate')));
+    expect(args, isNot(contains('--dwarf-stack-traces')));
+    expect(args.any((String a) => a.startsWith('--save-debugging-info=')), isFalse);
+  });
+
+  testWithoutContext('passes --obfuscate when kDartObfuscation is true', () {
+    final List<String> args = argsFor(<String, String>{kDartObfuscation: 'true'});
+    expect(args, contains('--obfuscate'));
+  });
+
+  testWithoutContext('does not pass --obfuscate when kDartObfuscation is false', () {
+    final List<String> args = argsFor(<String, String>{kDartObfuscation: 'false'});
+    expect(args, isNot(contains('--obfuscate')));
+  });
+
+  testWithoutContext(
+    'emits DWARF flags and arch-named symbols path when split-debug-info is set',
+    () {
+      final List<String> args = argsFor(<String, String>{kSplitDebugInfo: '/symbols'});
+      expect(args, contains('--dwarf-stack-traces'));
+      expect(args, contains('--resolve-dwarf-paths'));
+      expect(args, contains('--save-debugging-info=/symbols/app.ios-arm64.symbols'));
+    },
+  );
+
+  testWithoutContext('ignores an empty split-debug-info value', () {
+    final List<String> args = argsFor(<String, String>{kSplitDebugInfo: ''});
+    expect(args, isNot(contains('--dwarf-stack-traces')));
+    expect(args.any((String a) => a.startsWith('--save-debugging-info=')), isFalse);
+  });
+
+  testWithoutContext('forwards extra gen_snapshot options', () {
+    final List<String> args = argsFor(<String, String>{
+      kExtraGenSnapshotOptions: '--foo,--bar=baz',
+    });
+    expect(args, containsAllInOrder(<String>['--foo', '--bar=baz']));
+    // Extra options precede the kernel path.
+    expect(args.indexOf('--bar=baz'), lessThan(args.indexOf('/out/app.dill')));
+  });
+
+  testWithoutContext('combines obfuscation, split-debug-info, and extra options', () {
+    final List<String> args = argsFor(<String, String>{
+      kDartObfuscation: 'true',
+      kSplitDebugInfo: '/symbols',
+      kExtraGenSnapshotOptions: '--write-v8-snapshot-profile-to=/tmp/p.json',
+    });
+    expect(args, contains('--obfuscate'));
+    expect(args, contains('--save-debugging-info=/symbols/app.ios-arm64.symbols'));
+    expect(args, contains('--write-v8-snapshot-profile-to=/tmp/p.json'));
+    expect(args.last, '/out/app.dill');
+  });
+}

--- a/test/general/tvos_aot_snapshot_test.dart
+++ b/test/general/tvos_aot_snapshot_test.dart
@@ -46,7 +46,16 @@ void main() {
   });
 
   testWithoutContext('passes --obfuscate when kDartObfuscation is true', () {
-    final List<String> args = argsFor(<String, String>{kDartObfuscation: 'true'});
+    // The helper is tested in isolation. In production, obfuscation always
+    // arrives paired with split-debug-info: upstream FlutterCommand.getBuildInfo
+    // rejects `--obfuscate` without `--split-debug-info` (throwToolExit) before
+    // the defines ever reach this helper, so we use the reachable combination.
+    // Note the helper still emits `--obfuscate` independently of split-debug-info,
+    // matching AOTSnapshotter.build (build.dart) which does not gate one on the other.
+    final List<String> args = argsFor(<String, String>{
+      kDartObfuscation: 'true',
+      kSplitDebugInfo: '/symbols',
+    });
     expect(args, contains('--obfuscate'));
   });
 
@@ -61,7 +70,7 @@ void main() {
       final List<String> args = argsFor(<String, String>{kSplitDebugInfo: '/symbols'});
       expect(args, contains('--dwarf-stack-traces'));
       expect(args, contains('--resolve-dwarf-paths'));
-      expect(args, contains('--save-debugging-info=/symbols/app.ios-arm64.symbols'));
+      expect(args, contains('--save-debugging-info=/symbols/app.tvos-arm64.symbols'));
     },
   );
 
@@ -87,7 +96,7 @@ void main() {
       kExtraGenSnapshotOptions: '--write-v8-snapshot-profile-to=/tmp/p.json',
     });
     expect(args, contains('--obfuscate'));
-    expect(args, contains('--save-debugging-info=/symbols/app.ios-arm64.symbols'));
+    expect(args, contains('--save-debugging-info=/symbols/app.tvos-arm64.symbols'));
     expect(args, contains('--write-v8-snapshot-profile-to=/tmp/p.json'));
     expect(args.last, '/out/app.dill');
   });


### PR DESCRIPTION
## Summary
- The tvOS AOT step runs `gen_snapshot` directly (not upstream `AOTSnapshotter`) and previously dropped `--obfuscate` / `--split-debug-info` entirely — release/profile builds completed but the `App` binary kept readable Dart symbols and the split-debug-info directory stayed empty.
- The `gen_snapshot` invocation now forwards `--obfuscate`, the `--dwarf-stack-traces` / `--resolve-dwarf-paths` / `--save-debugging-info=<dir>/app.ios-arm64.symbols` trio, and any `--extra-gen-snapshot-options`, matching `AOTSnapshotter.build`.
- Arg construction extracted into a testable `tvosGenSnapshotArgs` helper; bumped to 1.1.1.

## Test plan
- [x] `dart analyze --fatal-infos` clean on changed files
- [x] New unit tests (`test/general/tvos_aot_snapshot_test.dart`) cover the flag matrix — 8/8 passing
- [x] Manual A/B release build of a demo app: app Dart symbols drop from present to 0 hits with the flags, and `app.ios-arm64.symbols` is written

Fixes #10