### PR TITLE
feat(cli): add `flutter-tvos upgrade`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to flutter-tvos will be documented here.
 
+## [Unreleased]
+
+### Added
+- **`flutter-tvos upgrade`** — upgrades the flutter-tvos toolchain to the latest
+  released version. Unlike stock `flutter upgrade` (which moves the bundled
+  Flutter SDK toward upstream and would break our pinned Flutter ↔ engine-artifact
+  contract), this resets the flutter-tvos checkout to its newest release tag
+  (`v<flutter>-tvos.<tool>`, e.g. `v3.44.1-tvos.1.2.0`) — bumping the pinned
+  Flutter version and matching tvOS engine artifacts together — then re-runs
+  `precache`, `pub get`, and `doctor`. Supports `--verify-only` (check without
+  changing anything) and `--force` (discard local changes); refuses to run on a
+  dirty checkout otherwise. Mirrors how flutter-webos / flutter-tizen override
+  `upgrade`.
+
 ## [1.2.0] — 2026-06-05
 
 Minor release. Upgrades the pinned engine to Flutter **3.44.1**, makes
@@ -97,7 +111,6 @@ lldb→Xcode-debugger launch flow.
 - Added `TvosDevice.parseDeviceUdid` unit coverage (extract UDID from
   `devicectl` JSON, null on missing / malformed) in
   `tvos_physical_device_test.dart`.
-
 ## [1.1.1] — 2026-05-28
 
 Patch release. No Flutter SDK or engine-artefact change — pinned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ All notable changes to flutter-tvos will be documented here.
   Flutter version and matching tvOS engine artifacts together — then re-runs
   `precache`, `pub get`, and `doctor`. Supports `--verify-only` (check without
   changing anything) and `--force` (discard local changes); refuses to run on a
-  dirty checkout otherwise. Mirrors how flutter-webos / flutter-tizen override
-  `upgrade`.
+  dirty checkout otherwise.
 
 ## [1.2.0] — 2026-06-05
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ flutter-tvos run -d <device_id> --release
 
 - See [Supported commands](doc/commands.md) for all available commands and usage examples.
 - See [Getting started](doc/get-started.md) to create your first app and try **hot reload**.
-- To **update** flutter-tvos, run `git pull` in the cloned directory.
+- To **update** flutter-tvos to the latest released version, run `flutter-tvos upgrade` (use `flutter-tvos upgrade --verify-only` to just check).
 
 ## Platform identity & limitations
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -174,6 +174,13 @@ The following commands from the [Flutter CLI](https://flutter.dev/docs/reference
   Upgrading refuses to run if your checkout has uncommitted changes; pass
   `--force` to discard them and upgrade anyway.
 
+  > **Note:** the upgrade moves your checkout with `git reset --hard` to the
+  > release commit. Uncommitted changes are guarded by the check above, but any
+  > **committed-but-unpushed** work on your current branch is discarded. This
+  > matches the recommended setup (clone the repo and stay on `main`). After
+  > upgrading, `pubspec.lock` will show as modified — that is the expected
+  > `pub get` output.
+
 ## Not supported
 
 The following commands from the Flutter CLI are not supported by flutter-tvos.

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -155,6 +155,25 @@ The following commands from the [Flutter CLI](https://flutter.dev/docs/reference
 
   For integration tests that must run on device, use the [`drive`](#drive) command instead.
 
+- ### `upgrade`
+
+  Upgrade the flutter-tvos toolchain to the **latest released version**. Unlike
+  stock `flutter upgrade` (which moves the bundled Flutter SDK toward upstream),
+  this updates your flutter-tvos checkout to its newest release tag — which bumps
+  the pinned Flutter version and the matching tvOS engine artifacts together —
+  and then re-downloads the correct engine.
+
+  ```sh
+  # Check whether a newer flutter-tvos release is available (no changes made).
+  flutter-tvos upgrade --verify-only
+
+  # Upgrade to the latest released version.
+  flutter-tvos upgrade
+  ```
+
+  Upgrading refuses to run if your checkout has uncommitted changes; pass
+  `--force` to discard them and upgrade anyway.
+
 ## Not supported
 
 The following commands from the Flutter CLI are not supported by flutter-tvos.
@@ -170,4 +189,3 @@ The following commands from the Flutter CLI are not supported by flutter-tvos.
 - `logs`
 - `screenshot`
 - `symbolize`
-- `upgrade`

--- a/lib/commands/upgrade.dart
+++ b/lib/commands/upgrade.dart
@@ -29,9 +29,7 @@ import 'package:meta/meta.dart';
 /// Release tags follow `v<flutter-version>-tvos.<tool-version>`, e.g.
 /// `v3.44.1-tvos.1.2.0`. The newest tag by version order is the target.
 ///
-/// Mirrors the structure of stock `UpgradeCommand` / `UpgradeCommandRunner` and
-/// the flutter-webos/flutter-tizen embedders, which override `upgrade` the same
-/// way.
+/// Mirrors the structure of stock `UpgradeCommand` / `UpgradeCommandRunner`.
 class TvosUpgradeCommand extends UpgradeCommand {
   TvosUpgradeCommand({required super.verboseHelp});
 

--- a/lib/commands/upgrade.dart
+++ b/lib/commands/upgrade.dart
@@ -1,0 +1,315 @@
+// Copyright 2026 The FlutterTV Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/os.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/upgrade.dart';
+import 'package:flutter_tools/src/dart/pub.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/runner/flutter_command.dart';
+import 'package:meta/meta.dart';
+
+/// `flutter-tvos upgrade` — upgrades the flutter-tvos toolchain itself to the
+/// latest released version.
+///
+/// Unlike stock `flutter upgrade` (which moves the vendored Flutter SDK toward
+/// upstream and would break our pinned `flutter.version` ↔ engine-artifact
+/// contract), this command upgrades the **flutter-tvos checkout** to its
+/// newest release tag. A release tag bumps the pinned Flutter version *and* the
+/// matching engine artifacts together, so after the upgrade `precache` pulls
+/// the correct engine for the new pin.
+///
+/// Release tags follow `v<flutter-version>-tvos.<tool-version>`, e.g.
+/// `v3.44.1-tvos.1.2.0`. The newest tag by version order is the target.
+///
+/// Mirrors the structure of stock `UpgradeCommand` / `UpgradeCommandRunner` and
+/// the flutter-webos/flutter-tizen embedders, which override `upgrade` the same
+/// way.
+class TvosUpgradeCommand extends UpgradeCommand {
+  TvosUpgradeCommand({required super.verboseHelp});
+
+  @override
+  String get description =>
+      'Upgrade the flutter-tvos toolchain to the latest released version.';
+
+  @override
+  Future<FlutterCommandResult> runCommand() {
+    final commandRunner = TvosUpgradeCommandRunner();
+    // Cache.flutterRoot points at the vendored `flutter/` SDK; its parent is
+    // the flutter-tvos repo root (where `.git` and `bin/flutter-tvos` live).
+    commandRunner.workingDirectory =
+        stringArg('working-directory') ?? globals.fs.directory(Cache.flutterRoot).parent.path;
+    return commandRunner.runCommand(
+      force: boolArg('force'),
+      continueFlow: boolArg('continue'),
+      testFlow: stringArg('working-directory') != null,
+      verifyOnly: boolArg('verify-only'),
+    );
+  }
+}
+
+/// A resolved point in the flutter-tvos git history.
+@immutable
+class TvosVersion {
+  const TvosVersion({required this.hash, required this.tag});
+
+  /// Full git commit hash.
+  final String hash;
+
+  /// The exact release tag at this commit, or null if the commit is not
+  /// tagged (e.g. a development checkout on a branch).
+  final String? tag;
+
+  String get hashShort => hash.length >= 10 ? hash.substring(0, 10) : hash;
+
+  /// Human label: the tag when present, otherwise the short hash.
+  String get label => tag ?? hashShort;
+}
+
+@visibleForTesting
+class TvosUpgradeCommandRunner {
+  String? workingDirectory;
+
+  /// Matches flutter-tvos release tags: `v<flutter>-tvos.<tool>`, e.g.
+  /// `v3.44.1-tvos.1.2.0`.
+  static final RegExp releaseTagPattern = RegExp(r'^v\d+\.\d+\.\d+-tvos\.\d+\.\d+\.\d+$');
+
+  /// Selects the newest release tag from [tags], which are expected to be
+  /// pre-sorted newest-first (`git tag -l --sort=-v:refname`). Non-release
+  /// tags are ignored. Returns null when no release tag is present.
+  @visibleForTesting
+  static String? latestReleaseTag(List<String> tags) {
+    for (final tag in tags) {
+      if (releaseTagPattern.hasMatch(tag.trim())) {
+        return tag.trim();
+      }
+    }
+    return null;
+  }
+
+  Future<FlutterCommandResult> runCommand({
+    required bool force,
+    required bool continueFlow,
+    required bool testFlow,
+    required bool verifyOnly,
+  }) async {
+    if (!continueFlow) {
+      await runCommandFirstHalf(force: force, testFlow: testFlow, verifyOnly: verifyOnly);
+    } else {
+      await runCommandSecondHalf();
+    }
+    return FlutterCommandResult.success();
+  }
+
+  Future<void> runCommandFirstHalf({
+    required bool force,
+    required bool testFlow,
+    required bool verifyOnly,
+  }) async {
+    final TvosVersion upstream = await fetchLatestReleaseVersion();
+    final TvosVersion current = await fetchCurrentVersion();
+
+    if (current.hash == upstream.hash) {
+      globals.printStatus('flutter-tvos is already up to date at ${upstream.label}.');
+      return;
+    }
+
+    globals.printStatus('A new version of flutter-tvos is available.\n');
+    globals.printStatus('  Latest:  ${upstream.label}', emphasis: true);
+    globals.printStatus('  Current: ${current.label}\n');
+
+    if (verifyOnly) {
+      globals.printStatus('To upgrade now, run "flutter-tvos upgrade".');
+      return;
+    }
+
+    // Guard against silently discarding local changes with `git reset --hard`.
+    if (!force && await _hasUncommittedChanges()) {
+      throwToolExit(
+        'Your flutter-tvos checkout in $workingDirectory has uncommitted changes.\n'
+        'Commit or stash them first, or re-run with --force to discard them and '
+        'upgrade anyway.',
+      );
+    }
+
+    globals.printStatus(
+      'Upgrading flutter-tvos to ${upstream.label} from ${current.label} in $workingDirectory...',
+    );
+    await attemptReset(upstream.hash);
+    if (!testFlow) {
+      await flutterUpgradeContinue();
+    }
+  }
+
+  /// Fetches tags from the remote and resolves the newest release tag.
+  Future<TvosVersion> fetchLatestReleaseVersion() async {
+    String tag;
+    String hash;
+    try {
+      await globals.processUtils.run(
+        <String>['git', 'fetch', '--tags'],
+        throwOnError: true,
+        workingDirectory: workingDirectory,
+      );
+      final RunResult result = await globals.processUtils.run(
+        <String>['git', 'tag', '-l', '--sort=-v:refname'],
+        throwOnError: true,
+        workingDirectory: workingDirectory,
+      );
+      final List<String> tags = const LineSplitter().convert(result.stdout.trim());
+      final String? latest = latestReleaseTag(tags);
+      if (latest == null) {
+        throwToolExit(
+          'Unable to upgrade flutter-tvos: no release tags '
+          '(v<flutter>-tvos.<version>) were found.\n'
+          'Make sure your flutter-tvos checkout tracks the upstream repository.',
+        );
+      }
+      tag = latest;
+      final RunResult revParse = await globals.processUtils.run(
+        <String>['git', 'rev-parse', tag],
+        throwOnError: true,
+        workingDirectory: workingDirectory,
+      );
+      hash = revParse.stdout.trim();
+    } on ProcessException catch (e) {
+      throwToolExit(
+        'Unable to upgrade flutter-tvos: could not query git tags.\n${e.message}',
+      );
+    }
+    return TvosVersion(hash: hash, tag: tag);
+  }
+
+  /// Resolves the commit the checkout is currently on, and its exact tag if any.
+  Future<TvosVersion> fetchCurrentVersion() async {
+    String hash;
+    String? tag;
+    try {
+      final RunResult head = await globals.processUtils.run(
+        <String>['git', 'rev-parse', '--verify', 'HEAD'],
+        throwOnError: true,
+        workingDirectory: workingDirectory,
+      );
+      hash = head.stdout.trim();
+    } on ProcessException catch (e) {
+      throwToolExit(
+        'Unable to upgrade flutter-tvos: could not determine the current '
+        'revision of $workingDirectory.\n${e.message}',
+      );
+    }
+    // An exact tag is best-effort; a development checkout legitimately has none.
+    try {
+      final RunResult describe = await globals.processUtils.run(
+        <String>['git', 'describe', '--exact-match', '--tags', 'HEAD'],
+        workingDirectory: workingDirectory,
+      );
+      if (describe.exitCode == 0) {
+        tag = describe.stdout.trim();
+      }
+    } on ProcessException {
+      tag = null;
+    }
+    return TvosVersion(hash: hash, tag: tag);
+  }
+
+  Future<bool> _hasUncommittedChanges() async {
+    final RunResult result = await globals.processUtils.run(
+      <String>['git', 'status', '-s'],
+      workingDirectory: workingDirectory,
+    );
+    return result.stdout.trim().isNotEmpty;
+  }
+
+  Future<void> attemptReset(String newRevision) async {
+    try {
+      await globals.processUtils.run(
+        <String>['git', 'reset', '--hard', newRevision],
+        throwOnError: true,
+        workingDirectory: workingDirectory,
+      );
+    } on ProcessException catch (e) {
+      throwToolExit(e.message, exitCode: e.errorCode);
+    }
+  }
+
+  /// Re-invokes `flutter-tvos upgrade --continue` so the *new* version of the
+  /// tool runs the second half (precache / pub get / doctor).
+  Future<void> flutterUpgradeContinue() async {
+    final int code = await globals.processUtils.stream(
+      <String>[
+        globals.fs.path.join('bin', 'flutter-tvos'),
+        'upgrade',
+        '--continue',
+        '--no-version-check',
+      ],
+      workingDirectory: workingDirectory,
+      allowReentrantFlutter: true,
+      environment: Map<String, String>.of(globals.platform.environment),
+    );
+    if (code != 0) {
+      throwToolExit(null, exitCode: code);
+    }
+  }
+
+  Future<void> runCommandSecondHalf() async {
+    globals.persistentToolState?.setShouldRedisplayWelcomeMessage(false);
+    await precacheArtifacts();
+    await updatePackages();
+    await runDoctor();
+    globals.persistentToolState?.setShouldRedisplayWelcomeMessage(true);
+  }
+
+  /// Re-downloads the tvOS engine artifacts that match the new pinned version.
+  Future<void> precacheArtifacts() async {
+    globals.printStatus('');
+    globals.printStatus('Upgrading engine...');
+    final int code = await globals.processUtils.stream(
+      <String>[
+        globals.fs.path.join('bin', 'flutter-tvos'),
+        '--no-color',
+        '--no-version-check',
+        'precache',
+        '--force',
+      ],
+      workingDirectory: workingDirectory,
+      allowReentrantFlutter: true,
+      environment: Map<String, String>.of(globals.platform.environment),
+    );
+    if (code != 0) {
+      throwToolExit(null, exitCode: code);
+    }
+  }
+
+  Future<void> updatePackages() async {
+    final String? projectRoot = findProjectRoot(globals.fs);
+    if (projectRoot != null) {
+      globals.printStatus('');
+      await pub.get(
+        context: PubContext.pubUpgrade,
+        project: FlutterProject.fromDirectory(globals.fs.directory(projectRoot)),
+        upgrade: true,
+      );
+    }
+  }
+
+  Future<void> runDoctor() async {
+    globals.printStatus('');
+    globals.printStatus('Running flutter-tvos doctor...');
+    await globals.processUtils.stream(
+      <String>[
+        globals.fs.path.join('bin', 'flutter-tvos'),
+        '--no-version-check',
+        'doctor',
+      ],
+      workingDirectory: workingDirectory,
+      allowReentrantFlutter: true,
+    );
+  }
+}

--- a/lib/commands/upgrade.dart
+++ b/lib/commands/upgrade.dart
@@ -75,6 +75,15 @@ class TvosVersion {
 
 @visibleForTesting
 class TvosUpgradeCommandRunner {
+  /// [processUtils] is injectable so tests can drive the git queries with a
+  /// `FakeProcessManager` without standing up Zone DI; production callers omit
+  /// it and fall back to [globals.processUtils].
+  TvosUpgradeCommandRunner({ProcessUtils? processUtils}) : _processUtils = processUtils;
+
+  final ProcessUtils? _processUtils;
+
+  ProcessUtils get _git => _processUtils ?? globals.processUtils;
+
   String? workingDirectory;
 
   /// Matches flutter-tvos release tags: `v<flutter>-tvos.<tool>`, e.g.
@@ -153,12 +162,12 @@ class TvosUpgradeCommandRunner {
     String tag;
     String hash;
     try {
-      await globals.processUtils.run(
+      await _git.run(
         <String>['git', 'fetch', '--tags'],
         throwOnError: true,
         workingDirectory: workingDirectory,
       );
-      final RunResult result = await globals.processUtils.run(
+      final RunResult result = await _git.run(
         <String>['git', 'tag', '-l', '--sort=-v:refname'],
         throwOnError: true,
         workingDirectory: workingDirectory,
@@ -173,8 +182,15 @@ class TvosUpgradeCommandRunner {
         );
       }
       tag = latest;
-      final RunResult revParse = await globals.processUtils.run(
-        <String>['git', 'rev-parse', tag],
+      // Peel to the underlying commit with `^{commit}`. Release tags may be
+      // annotated (e.g. v3.44.1-tvos.1.2.0), and `git rev-parse <annotated-tag>`
+      // returns the tag-object SHA, not the commit SHA. fetchCurrentVersion
+      // reads `git rev-parse HEAD` (a commit SHA), so without peeling the
+      // "already up to date" comparison would never match on a checkout sitting
+      // exactly on an annotated release. `^{commit}` is a no-op for lightweight
+      // tags.
+      final RunResult revParse = await _git.run(
+        <String>['git', 'rev-parse', '$tag^{commit}'],
         throwOnError: true,
         workingDirectory: workingDirectory,
       );
@@ -192,7 +208,7 @@ class TvosUpgradeCommandRunner {
     String hash;
     String? tag;
     try {
-      final RunResult head = await globals.processUtils.run(
+      final RunResult head = await _git.run(
         <String>['git', 'rev-parse', '--verify', 'HEAD'],
         throwOnError: true,
         workingDirectory: workingDirectory,
@@ -206,7 +222,7 @@ class TvosUpgradeCommandRunner {
     }
     // An exact tag is best-effort; a development checkout legitimately has none.
     try {
-      final RunResult describe = await globals.processUtils.run(
+      final RunResult describe = await _git.run(
         <String>['git', 'describe', '--exact-match', '--tags', 'HEAD'],
         workingDirectory: workingDirectory,
       );
@@ -220,7 +236,7 @@ class TvosUpgradeCommandRunner {
   }
 
   Future<bool> _hasUncommittedChanges() async {
-    final RunResult result = await globals.processUtils.run(
+    final RunResult result = await _git.run(
       <String>['git', 'status', '-s'],
       workingDirectory: workingDirectory,
     );
@@ -229,7 +245,7 @@ class TvosUpgradeCommandRunner {
 
   Future<void> attemptReset(String newRevision) async {
     try {
-      await globals.processUtils.run(
+      await _git.run(
         <String>['git', 'reset', '--hard', newRevision],
         throwOnError: true,
         workingDirectory: workingDirectory,

--- a/lib/commands/upgrade.dart
+++ b/lib/commands/upgrade.dart
@@ -6,13 +6,10 @@ import 'dart:convert';
 
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/upgrade.dart';
-import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:meta/meta.dart';
 
@@ -274,8 +271,13 @@ class TvosUpgradeCommandRunner {
 
   Future<void> runCommandSecondHalf() async {
     globals.persistentToolState?.setShouldRedisplayWelcomeMessage(false);
+    // No explicit `pub get` here: the second half is re-invoked through
+    // `bin/flutter-tvos`, whose bootstrap (`bin/internal/shared.sh`) already
+    // runs a plain `flutter pub get` against the tool repo when the snapshot
+    // stamp changes — which it always does after the reset to a new release.
+    // Running `pub get --upgrade` again would only churn `pubspec.lock`, which
+    // then trips the uncommitted-changes guard on the next upgrade.
     await precacheArtifacts();
-    await updatePackages();
     await runDoctor();
     globals.persistentToolState?.setShouldRedisplayWelcomeMessage(true);
   }
@@ -298,18 +300,6 @@ class TvosUpgradeCommandRunner {
     );
     if (code != 0) {
       throwToolExit(null, exitCode: code);
-    }
-  }
-
-  Future<void> updatePackages() async {
-    final String? projectRoot = findProjectRoot(globals.fs);
-    if (projectRoot != null) {
-      globals.printStatus('');
-      await pub.get(
-        context: PubContext.pubUpgrade,
-        project: FlutterProject.fromDirectory(globals.fs.directory(projectRoot)),
-        upgrade: true,
-      );
     }
   }
 

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -33,7 +33,6 @@ import 'package:flutter_tools/src/commands/screenshot.dart';
 import 'package:flutter_tools/src/commands/shell_completion.dart';
 import 'package:flutter_tools/src/commands/symbolize.dart';
 import 'package:flutter_tools/src/commands/update_packages.dart';
-import 'package:flutter_tools/src/commands/upgrade.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/features.dart';
@@ -55,6 +54,7 @@ import 'commands/plugin.dart';
 import 'commands/precache.dart';
 import 'commands/run.dart';
 import 'commands/test.dart';
+import 'commands/upgrade.dart';
 import 'tvos_application_package.dart';
 import 'tvos_artifacts.dart';
 import 'tvos_cache.dart';
@@ -130,8 +130,11 @@ Future<void> main(List<String> args) async {
       ShellCompletionCommand(),
       SymbolizeCommand(stdio: globals.stdio, fileSystem: globals.fs),
       UpdatePackagesCommand(verboseHelp: verboseHelp),
-      UpgradeCommand(verboseHelp: verboseHelp),
       // Commands extended for tvOS.
+      // `upgrade` is overridden so it upgrades the flutter-tvos toolchain to its
+      // latest release tag instead of moving the pinned Flutter SDK upstream
+      // (which stock UpgradeCommand would do, breaking the engine-artifact pin).
+      TvosUpgradeCommand(verboseHelp: verboseHelp),
       TvosAttachCommand(
         verboseHelp: verboseHelp,
         stdio: globals.stdio,

--- a/test/general/tvos_upgrade_test.dart
+++ b/test/general/tvos_upgrade_test.dart
@@ -1,0 +1,76 @@
+// Copyright 2026 The FlutterTV Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tvos/commands/upgrade.dart';
+
+import '../src/common.dart';
+
+void main() {
+  group('TvosUpgradeCommandRunner.latestReleaseTag', () {
+    // Mimics `git tag -l --sort=-v:refname` output: newest first.
+    const realTags = <String>[
+      'v3.44.1-tvos.1.2.0',
+      'v3.44.0-tvos.1.1.1',
+      'v3.44.0-tvos.1.1.0',
+      'v3.41.9-tvos.1.1.0',
+      'v3.41.9-tvos.1.0.1',
+      'v3.41.4-tvos.1.0.0',
+    ];
+
+    test('picks the newest release tag from a version-sorted list', () {
+      expect(TvosUpgradeCommandRunner.latestReleaseTag(realTags), 'v3.44.1-tvos.1.2.0');
+    });
+
+    test('ignores tags that are not flutter-tvos release tags', () {
+      final tags = <String>[
+        'nightly',
+        'latest',
+        'v3.44.1', // plain Flutter-style tag, not ours
+        'tvos.1.2.0', // missing the v<flutter> prefix
+        'v3.44.0-tvos.1.1.1', // first real match
+        'v3.41.4-tvos.1.0.0',
+      ];
+      expect(TvosUpgradeCommandRunner.latestReleaseTag(tags), 'v3.44.0-tvos.1.1.1');
+    });
+
+    test('returns null when there are no release tags', () {
+      expect(TvosUpgradeCommandRunner.latestReleaseTag(const <String>['nightly', 'foo']), isNull);
+      expect(TvosUpgradeCommandRunner.latestReleaseTag(const <String>[]), isNull);
+    });
+
+    test('trims surrounding whitespace on the matched tag', () {
+      expect(
+        TvosUpgradeCommandRunner.latestReleaseTag(const <String>['  v3.44.1-tvos.1.2.0  ']),
+        'v3.44.1-tvos.1.2.0',
+      );
+    });
+
+    test('release tag pattern only matches the v<flutter>-tvos.<tool> shape', () {
+      final RegExp p = TvosUpgradeCommandRunner.releaseTagPattern;
+      expect(p.hasMatch('v3.44.1-tvos.1.2.0'), isTrue);
+      expect(p.hasMatch('v10.0.0-tvos.12.34.56'), isTrue);
+      expect(p.hasMatch('v3.44.1-tvos.1.2'), isFalse); // tool version needs 3 parts
+      expect(p.hasMatch('3.44.1-tvos.1.2.0'), isFalse); // missing leading v
+      expect(p.hasMatch('v3.44.1-ios.1.2.0'), isFalse); // wrong platform infix
+    });
+  });
+
+  group('TvosVersion', () {
+    test('label is the tag when tagged', () {
+      const version = TvosVersion(hash: 'abcdef1234567890', tag: 'v3.44.1-tvos.1.2.0');
+      expect(version.label, 'v3.44.1-tvos.1.2.0');
+    });
+
+    test('label falls back to the short hash when untagged', () {
+      const version = TvosVersion(hash: 'abcdef1234567890', tag: null);
+      expect(version.label, 'abcdef1234');
+      expect(version.hashShort, 'abcdef1234');
+    });
+
+    test('hashShort tolerates a hash shorter than 10 chars', () {
+      const version = TvosVersion(hash: 'abc123', tag: null);
+      expect(version.hashShort, 'abc123');
+    });
+  });
+}

--- a/test/general/tvos_upgrade_test.dart
+++ b/test/general/tvos_upgrade_test.dart
@@ -2,9 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tvos/commands/upgrade.dart';
 
 import '../src/common.dart';
+import '../src/fake_process_manager.dart';
 
 void main() {
   group('TvosUpgradeCommandRunner.latestReleaseTag', () {
@@ -53,6 +56,76 @@ void main() {
       expect(p.hasMatch('v3.44.1-tvos.1.2'), isFalse); // tool version needs 3 parts
       expect(p.hasMatch('3.44.1-tvos.1.2.0'), isFalse); // missing leading v
       expect(p.hasMatch('v3.44.1-ios.1.2.0'), isFalse); // wrong platform infix
+    });
+  });
+
+  group('TvosUpgradeCommandRunner.fetchLatestReleaseVersion', () {
+    late FakeProcessManager processManager;
+    late TvosUpgradeCommandRunner runner;
+
+    setUp(() {
+      processManager = FakeProcessManager.empty();
+      runner = TvosUpgradeCommandRunner(
+        processUtils: ProcessUtils(
+          processManager: processManager,
+          logger: BufferLogger.test(),
+        ),
+      )..workingDirectory = '/repo';
+    });
+
+    test('peels annotated release tags to the underlying commit SHA', () async {
+      // An annotated tag: `git rev-parse <tag>` would return the tag-object
+      // SHA, but `<tag>^{commit}` must resolve to the commit so the result is
+      // comparable to `git rev-parse HEAD`.
+      processManager.addCommands(<FakeCommand>[
+        const FakeCommand(command: <String>['git', 'fetch', '--tags']),
+        const FakeCommand(
+          command: <String>['git', 'tag', '-l', '--sort=-v:refname'],
+          stdout: 'v3.44.1-tvos.1.2.0\nv3.44.0-tvos.1.1.1\n',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', 'v3.44.1-tvos.1.2.0^{commit}'],
+          stdout: '840123adb831536a3512df43355dd355c9a77878\n',
+        ),
+      ]);
+
+      final TvosVersion upstream = await runner.fetchLatestReleaseVersion();
+
+      expect(upstream.tag, 'v3.44.1-tvos.1.2.0');
+      expect(upstream.hash, '840123adb831536a3512df43355dd355c9a77878');
+      expect(processManager, hasNoRemainingExpectations);
+    });
+
+    test('skips non-release tags when choosing the newest', () async {
+      processManager.addCommands(<FakeCommand>[
+        const FakeCommand(command: <String>['git', 'fetch', '--tags']),
+        const FakeCommand(
+          command: <String>['git', 'tag', '-l', '--sort=-v:refname'],
+          stdout: 'nightly\nlatest\nv3.44.0-tvos.1.1.1\nv3.41.4-tvos.1.0.0\n',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', 'v3.44.0-tvos.1.1.1^{commit}'],
+          stdout: 'cafebabecafebabecafebabecafebabecafebabe\n',
+        ),
+      ]);
+
+      final TvosVersion upstream = await runner.fetchLatestReleaseVersion();
+
+      expect(upstream.tag, 'v3.44.0-tvos.1.1.1');
+      expect(upstream.hash, 'cafebabecafebabecafebabecafebabecafebabe');
+      expect(processManager, hasNoRemainingExpectations);
+    });
+
+    test('throws a tool exit when no release tags exist', () async {
+      processManager.addCommands(<FakeCommand>[
+        const FakeCommand(command: <String>['git', 'fetch', '--tags']),
+        const FakeCommand(
+          command: <String>['git', 'tag', '-l', '--sort=-v:refname'],
+          stdout: 'nightly\nlatest\n',
+        ),
+      ]);
+
+      await expectToolExitLater(runner.fetchLatestReleaseVersion(), contains('no release tags'));
     });
   });
 

--- a/test/general/tvos_upgrade_test.dart
+++ b/test/general/tvos_upgrade_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tvos/commands/upgrade.dart';
 
 import '../src/common.dart';
+import '../src/context.dart';
 import '../src/fake_process_manager.dart';
 
 void main() {
@@ -127,6 +128,149 @@ void main() {
 
       await expectToolExitLater(runner.fetchLatestReleaseVersion(), contains('no release tags'));
     });
+  });
+
+  group('TvosUpgradeCommandRunner.fetchCurrentVersion', () {
+    late FakeProcessManager processManager;
+    late TvosUpgradeCommandRunner runner;
+
+    setUp(() {
+      processManager = FakeProcessManager.empty();
+      runner = TvosUpgradeCommandRunner(
+        processUtils: ProcessUtils(
+          processManager: processManager,
+          logger: BufferLogger.test(),
+        ),
+      )..workingDirectory = '/repo';
+    });
+
+    test('returns the commit hash and exact tag when HEAD is tagged', () async {
+      processManager.addCommands(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+          stdout: '840123adb831536a3512df43355dd355c9a77878\n',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'describe', '--exact-match', '--tags', 'HEAD'],
+          stdout: 'v3.44.1-tvos.1.2.0\n',
+        ),
+      ]);
+
+      final TvosVersion current = await runner.fetchCurrentVersion();
+
+      expect(current.hash, '840123adb831536a3512df43355dd355c9a77878');
+      expect(current.tag, 'v3.44.1-tvos.1.2.0');
+      expect(current.label, 'v3.44.1-tvos.1.2.0');
+      expect(processManager, hasNoRemainingExpectations);
+    });
+
+    test('leaves tag null on a development checkout with no exact tag', () async {
+      processManager.addCommands(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+          stdout: 'cafef00dcafef00dcafef00dcafef00dcafef00d\n',
+        ),
+        // `git describe --exact-match` exits non-zero when HEAD is not on a tag.
+        const FakeCommand(
+          command: <String>['git', 'describe', '--exact-match', '--tags', 'HEAD'],
+          exitCode: 128,
+        ),
+      ]);
+
+      final TvosVersion current = await runner.fetchCurrentVersion();
+
+      expect(current.hash, 'cafef00dcafef00dcafef00dcafef00dcafef00d');
+      expect(current.tag, isNull);
+      expect(current.label, 'cafef00dca'); // short hash fallback
+      expect(processManager, hasNoRemainingExpectations);
+    });
+  });
+
+  group('TvosUpgradeCommandRunner.runCommandFirstHalf', () {
+    late FakeProcessManager processManager;
+    late BufferLogger logger;
+
+    setUp(() {
+      processManager = FakeProcessManager.empty();
+      logger = BufferLogger.test();
+    });
+
+    const sha = '840123adb831536a3512df43355dd355c9a77878';
+
+    testUsingContext(
+      'reports already up to date when HEAD is the latest (annotated) release',
+      () async {
+        processManager.addCommands(<FakeCommand>[
+          const FakeCommand(command: <String>['git', 'fetch', '--tags']),
+          const FakeCommand(
+            command: <String>['git', 'tag', '-l', '--sort=-v:refname'],
+            stdout: 'v3.44.1-tvos.1.2.0\n',
+          ),
+          const FakeCommand(
+            command: <String>['git', 'rev-parse', 'v3.44.1-tvos.1.2.0^{commit}'],
+            stdout: '$sha\n',
+          ),
+          const FakeCommand(
+            command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+            stdout: '$sha\n',
+          ),
+          const FakeCommand(
+            command: <String>['git', 'describe', '--exact-match', '--tags', 'HEAD'],
+            stdout: 'v3.44.1-tvos.1.2.0\n',
+          ),
+        ]);
+
+        final runner = TvosUpgradeCommandRunner()..workingDirectory = '/repo';
+        await runner.runCommandFirstHalf(force: false, testFlow: true, verifyOnly: false);
+
+        expect(logger.statusText, contains('already up to date at v3.44.1-tvos.1.2.0'));
+        expect(processManager, hasNoRemainingExpectations);
+      },
+      overrides: <Type, Generator>{
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'refuses to upgrade a dirty checkout without --force',
+      () async {
+        processManager.addCommands(<FakeCommand>[
+          const FakeCommand(command: <String>['git', 'fetch', '--tags']),
+          const FakeCommand(
+            command: <String>['git', 'tag', '-l', '--sort=-v:refname'],
+            stdout: 'v3.44.1-tvos.1.2.0\n',
+          ),
+          const FakeCommand(
+            command: <String>['git', 'rev-parse', 'v3.44.1-tvos.1.2.0^{commit}'],
+            stdout: '$sha\n',
+          ),
+          const FakeCommand(
+            command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+            stdout: 'feedfacefeedfacefeedfacefeedfacefeedface\n',
+          ),
+          const FakeCommand(
+            command: <String>['git', 'describe', '--exact-match', '--tags', 'HEAD'],
+            exitCode: 128,
+          ),
+          const FakeCommand(
+            command: <String>['git', 'status', '-s'],
+            stdout: ' M lib/foo.dart\n',
+          ),
+        ]);
+
+        final runner = TvosUpgradeCommandRunner()..workingDirectory = '/repo';
+        await expectToolExitLater(
+          runner.runCommandFirstHalf(force: false, testFlow: true, verifyOnly: false),
+          contains('uncommitted changes'),
+        );
+        expect(processManager, hasNoRemainingExpectations);
+      },
+      overrides: <Type, Generator>{
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
   });
 
   group('TvosVersion', () {


### PR DESCRIPTION
## Summary

Adds **`flutter-tvos upgrade`** — upgrades the flutter-tvos toolchain itself to the latest released version, the way `flutter upgrade` does for stock Flutter.

Targets **`dev`** (new integration branch). Features land on `dev`; promoting `dev → main` plus a `v*.*.*` tag is what cuts an actual release.

### Why a custom upgrade
Stock `flutter upgrade` moves the *vendored* Flutter SDK toward upstream, which would break our pinned `flutter.version` ↔ engine-artifact contract. Instead this command resets the **flutter-tvos checkout** to its newest release tag (`v<flutter>-tvos.<tool>`, e.g. `v3.44.1-tvos.1.2.0`) — bumping the pinned Flutter version *and* matching tvOS engine artifacts together — then re-runs `precache --force`, `pub get`, and `doctor`.

### Behaviour
- `flutter-tvos upgrade` — fetch tags, resolve newest release, `git reset --hard` to it, then re-invoke the new tool's `--continue` half (precache / pub get / doctor).
- `flutter-tvos upgrade --verify-only` — report latest vs current without changing anything.
- `--force` — discard local changes; otherwise refuses to run on a dirty checkout. (The hard reset also discards committed-but-unpushed work on the current branch — documented in `doc/commands.md`.)

### Notable fix in this PR
Release tags can be **annotated** (e.g. `v3.44.1-tvos.1.2.0`). `git rev-parse <annotated-tag>` returns the tag-object SHA, but the current revision is read as `git rev-parse HEAD` (a commit SHA) — so the "already up to date" comparison would never match on a checkout sitting exactly on an annotated release, and the command always claimed an upgrade was available. Fixed by peeling with `<tag>^{commit}` (no-op for lightweight tags). The repo's tags are a mix of both, so this matters.

## Verification
- `--verify-only` against the real `v3.44.1-tvos.1.2.0` tag: correctly reports both "newer available" and "already up to date".
- **Full destructive rehearsal** in an isolated throwaway branch: a real `upgrade` climbed from an older commit to a simulated newer release, ran `git reset --hard` → `precache --force` (all 6 engine artifacts) → `pub get` → `doctor` (tvOS toolchain ✓), then was fully cleaned up.
- Unit tests: `latestReleaseTag` selection/pattern, `TvosVersion` labelling, and **new** `FakeProcessManager`-driven `fetchLatestReleaseVersion` tests (the `^{commit}` peel, non-release-tag skipping, no-release-tags tool exit). `TvosUpgradeCommandRunner` now takes an injectable `ProcessUtils` (defaults to globals) for this.
- `dart analyze lib/` clean; full suite **225/225** pass.

## Docs
- `README.md` — "update flutter-tvos" bullet pointing at `upgrade` / `--verify-only`.
- `doc/commands.md` — command reference plus the hard-reset caveat.
- `CHANGELOG.md` — entry under `[Unreleased]`.
