### PR TITLE
feat(flutter_tvos): Swift Package Manager support for the flutter_tvos FFI plugin (1.1.0)

### DIFF
--- a/packages/flutter_tvos/CHANGELOG.md
+++ b/packages/flutter_tvos/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.0
+
+- Added Swift Package Manager support: the package now ships a
+  `tvos/Package.swift` alongside the CocoaPods podspec, so apps built with
+  flutter-tvos 1.3+ resolve it via SwiftPM (the Flutter 3.44 default) while
+  CocoaPods projects keep working unchanged. The FFI exports are marked
+  `__attribute__((used))` / `visibility("default")` so they survive
+  dead-stripping when statically linked through the SPM umbrella — verified
+  in a release (AOT) build on a physical Apple TV. No API change.
+
 ## 1.0.5
 
 - Updated compatibility with Flutter 3.44.0.

--- a/packages/flutter_tvos/README.md
+++ b/packages/flutter_tvos/README.md
@@ -18,8 +18,16 @@ Add `flutter_tvos` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_tvos: ^1.0.4
+  flutter_tvos: ^1.1.0
 ```
+
+### Dependency management
+
+Supports both **Swift Package Manager** and **CocoaPods** from a single source
+tree. `flutter-tvos` wires the right one automatically: apps on Flutter 3.44+
+link the native FFI shim via SwiftPM (this package ships a
+`tvos/Package.swift`), while CocoaPods-based projects keep using the podspec.
+No manual setup needed.
 
 ## Usage
 

--- a/packages/flutter_tvos/example/tvos/Podfile
+++ b/packages/flutter_tvos/example/tvos/Podfile
@@ -25,7 +25,10 @@ target 'Runner' do
       plugin_name = plugin['name']
       plugin_path = plugin['path']
       tvos_dir = File.join(plugin_path, 'tvos')
-      if File.directory?(tvos_dir) && File.exist?(File.join(tvos_dir, "#{plugin_name}.podspec"))
+      # Plugins that ship a Package.swift are resolved via Swift Package Manager;
+      # skip them here so they are not linked twice (SPM + CocoaPods).
+      has_spm = File.exist?(File.join(tvos_dir, 'Package.swift'))
+      if File.directory?(tvos_dir) && !has_spm && File.exist?(File.join(tvos_dir, "#{plugin_name}.podspec"))
         pod plugin_name, :path => tvos_dir
       end
     end

--- a/packages/flutter_tvos/example/tvos/Runner.xcodeproj/project.pbxproj
+++ b/packages/flutter_tvos/example/tvos/Runner.xcodeproj/project.pbxproj
@@ -125,7 +125,6 @@
 				97C146EC1CF9000082B4168C /* Resources */,
 				AAF10000000000000000F00D /* Embed App.framework */,
 				9740EEB31CF901A200538489 /* Copy flutter_assets */,
-				95FF0C6DAEFDF6E10425A4AB /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -164,7 +163,7 @@
 			);
 			mainGroup = 97C146E51CF9000082B4168C;
 			packageReferences = (
-				AAF40000000000000000F00D /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+				AAF40000000000000000F00D /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
 			);
 			productRefGroup = 97C146EF1CF9000082B41690 /* Products */;
 			projectDirPath = "";
@@ -209,27 +208,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		95FF0C6DAEFDF6E10425A4AB /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9740EEB31CF901A200538489 /* Copy flutter_assets */ = {
@@ -556,7 +534,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		AAF40000000000000000F00D /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		AAF40000000000000000F00D /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};

--- a/packages/flutter_tvos/pubspec.lock
+++ b/packages/flutter_tvos/pubspec.lock
@@ -127,10 +127,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -209,5 +209,5 @@ packages:
     source: hosted
     version: "15.0.2"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.19.0"

--- a/packages/flutter_tvos/pubspec.yaml
+++ b/packages/flutter_tvos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_tvos
 description: Platform detection and utilities for Flutter apps running on Apple TV (tvOS). Provides runtime checks for tvOS, device info, and capability queries.
-version: 1.0.5
+version: 1.1.0
 homepage: https://fluttertv.dev
 repository: https://github.com/fluttertv/flutter-tvos
 issue_tracker: https://github.com/fluttertv/flutter-tvos/issues

--- a/packages/flutter_tvos/tvos/Classes/flutter_tvos_ffi.h
+++ b/packages/flutter_tvos/tvos/Classes/flutter_tvos_ffi.h
@@ -8,34 +8,44 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+// FFI symbols are looked up at runtime via `DynamicLibrary.process()`
+// (dlsym), so nothing in native code references them. Under CocoaPods the
+// plugin is a dynamic framework and its exported symbols survive. Under
+// Swift Package Manager the plugin is linked *statically* into Runner, where
+// the linker would dead-strip these otherwise-unreferenced functions. `used`
+// keeps them through dead-stripping and `visibility("default")` keeps them in
+// the dynamic symbol table so dlsym can find them. Harmless under CocoaPods.
+#define FLUTTER_TVOS_FFI_EXPORT \
+  __attribute__((used)) __attribute__((visibility("default")))
+
 /// Returns true if running on tvOS (compiled with TARGET_OS_TV).
-bool flutter_tvos_is_tvos(void);
+FLUTTER_TVOS_FFI_EXPORT bool flutter_tvos_is_tvos(void);
 
 /// Returns the OS version string (e.g., "18.4"). Caller must NOT free.
-const char* flutter_tvos_system_version(void);
+FLUTTER_TVOS_FFI_EXPORT const char* flutter_tvos_system_version(void);
 
 /// Returns the device model (e.g., "Apple TV"). Caller must NOT free.
-const char* flutter_tvos_device_model(void);
+FLUTTER_TVOS_FFI_EXPORT const char* flutter_tvos_device_model(void);
 
 /// Returns the machine identifier (e.g., "AppleTV14,1"). Caller must NOT free.
-const char* flutter_tvos_machine_id(void);
+FLUTTER_TVOS_FFI_EXPORT const char* flutter_tvos_machine_id(void);
 
 /// Returns true if running in the simulator.
-bool flutter_tvos_is_simulator(void);
+FLUTTER_TVOS_FFI_EXPORT bool flutter_tvos_is_simulator(void);
 
 /// Returns true if the display supports 4K (3840+ pixels wide).
-bool flutter_tvos_supports_4k(void);
+FLUTTER_TVOS_FFI_EXPORT bool flutter_tvos_supports_4k(void);
 
 /// Returns true if HDR is supported.
-bool flutter_tvos_supports_hdr(void);
+FLUTTER_TVOS_FFI_EXPORT bool flutter_tvos_supports_hdr(void);
 
 /// Returns true if multi-user is supported (tvOS 14+).
-bool flutter_tvos_supports_multi_user(void);
+FLUTTER_TVOS_FFI_EXPORT bool flutter_tvos_supports_multi_user(void);
 
 /// Returns the native display width in pixels.
-int32_t flutter_tvos_display_width(void);
+FLUTTER_TVOS_FFI_EXPORT int32_t flutter_tvos_display_width(void);
 
 /// Returns the native display height in pixels.
-int32_t flutter_tvos_display_height(void);
+FLUTTER_TVOS_FFI_EXPORT int32_t flutter_tvos_display_height(void);
 
 #endif /* FLUTTER_TVOS_FFI_H */

--- a/packages/flutter_tvos/tvos/Package.swift
+++ b/packages/flutter_tvos/tvos/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 5.9
+// Lets flutter_tvos be consumed via Swift Package Manager in addition to the
+// CocoaPods podspec. This is an FFI plugin: the target is the Objective-C
+// `Classes/flutter_tvos_ffi.{h,m}` shim that Dart calls through
+// `DynamicLibrary.process()`. It has no Flutter dependency (UIKit only).
+import PackageDescription
+
+let package = Package(
+  name: "flutter_tvos",
+  platforms: [
+    .tvOS(.v13),
+  ],
+  products: [
+    .library(name: "flutter-tvos", targets: ["flutter_tvos"]),
+  ],
+  targets: [
+    .target(
+      name: "flutter_tvos",
+      path: "Classes",
+      // The single header lives next to the source under Classes/.
+      publicHeadersPath: ".",
+      cSettings: [
+        .define("TARGET_OS_TV"),
+      ],
+      // flutter_tvos_ffi.m calls UIDevice / UIScreen.
+      linkerSettings: [
+        .linkedFramework("UIKit"),
+      ]
+    ),
+  ]
+)

--- a/packages/flutter_tvos/tvos/flutter_tvos.podspec
+++ b/packages/flutter_tvos/tvos/flutter_tvos.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_tvos'
-  s.version          = '1.0.0'
+  s.version          = '1.1.0'
   s.summary          = 'Platform detection and utilities for Flutter on tvOS (FFI).'
   s.description      = <<-DESC
 Provides runtime checks to determine if a Flutter app is running on Apple TV (tvOS),


### PR DESCRIPTION
## Summary

Adds **Swift Package Manager support to the `flutter_tvos` package itself** (1.1.0).

`flutter_tvos` is an **FFI** plugin — an Objective-C shim (`Classes/flutter_tvos_ffi.{h,m}`) the Dart side calls through `DynamicLibrary.process()`. This makes it consumable via SwiftPM in addition to its CocoaPods podspec, so it behaves like the federated `*_tvos` plugins under the new SPM-default build.

## What it does
- **`tvos/Package.swift`** — an Objective-C/C target (`path: Classes`, `publicHeadersPath: "."`, links `UIKit`). No Flutter dependency (UIKit only).
- **FFI export attributes** — the C functions get `__attribute__((used)) __attribute__((visibility("default")))`. Under CocoaPods the plugin is a dynamic framework and its symbols survive anyway; under SPM it's linked **statically** into Runner, where the linker would otherwise dead-strip these (nothing native references them — only Dart at runtime via `dlsym`). This keeps them present and in the dynamic symbol table.
- **Example Podfile skip-guard** — so a plugin that ships a `Package.swift` resolves via SPM only, never double-linked.
- Version bump `1.0.5 → 1.1.0` (pubspec + podspec), CHANGELOG + README notes.

## Why it matters
This was the open question after the SPM rollout: does an **FFI** plugin survive static linking through the umbrella? It does — verified empirically.

## Verification
- Example builds with `flutter_tvos` resolved via **SPM** on the simulator (Podfile skips it, umbrella links it).
- **Release (AOT) build** with the FFI symbols statically linked, confirmed `TVOSInfo` getters resolve at runtime on a physical Apple TV.
- Old-style projects (pre-SPM template) still resolve it via CocoaPods unchanged — no regression.

## Notes
- Pure additive: existing CocoaPods consumers are unaffected (the `used`/`visibility` attributes are no-ops there).
