### PR TITLE
fix: plugin discovery finds package_config.json in pub workspaces

### DIFF
--- a/lib/tvos_plugins.dart
+++ b/lib/tvos_plugins.dart
@@ -134,10 +134,21 @@ List<_DependencyPluginYaml> _walkPluginDependencies(FlutterProject project) {
       rawGraph is List<dynamic> ? rawGraph : <dynamic>[];
 
   // Build a name→path map from .dart_tool/package_config.json.
+  // Pub workspaces hoist package_config.json to the workspace root, so walk
+  // up from the project directory until one is found (the same resolution pub
+  // itself uses).
   final packagePaths = <String, String>{};
-  final File packageConfigFile = project.directory
+  File packageConfigFile = project.directory
       .childDirectory('.dart_tool')
       .childFile('package_config.json');
+  Directory packageConfigSearchDir = project.directory;
+  while (!packageConfigFile.existsSync() &&
+      packageConfigSearchDir.parent.path != packageConfigSearchDir.path) {
+    packageConfigSearchDir = packageConfigSearchDir.parent;
+    packageConfigFile = packageConfigSearchDir
+        .childDirectory('.dart_tool')
+        .childFile('package_config.json');
+  }
   if (packageConfigFile.existsSync()) {
     try {
       final packageConfig =
@@ -148,10 +159,12 @@ List<_DependencyPluginYaml> _walkPluginDependencies(FlutterProject project) {
         final pkgMap = pkg as Map<String, dynamic>;
         final name = pkgMap['name'] as String;
         var rootUri = pkgMap['rootUri'] as String;
-        // rootUri may be relative to .dart_tool/ or a file:// URI.
-        if (rootUri.startsWith('../')) {
+        // rootUri may be relative to the package_config.json's own directory
+        // (which is the workspace root's .dart_tool/ under pub workspaces) or
+        // a file:// URI.
+        if (rootUri.startsWith('../') || rootUri.startsWith('./')) {
           rootUri = globals.fs.path.normalize(
-            globals.fs.path.join(project.directory.path, '.dart_tool', rootUri),
+            globals.fs.path.join(packageConfigFile.parent.path, rootUri),
           );
         } else if (rootUri.startsWith('file://')) {
           rootUri = Uri.parse(rootUri).toFilePath();


### PR DESCRIPTION
## Problem

`_walkPluginDependencies` resolves plugin paths through `<project>/.dart_tool/package_config.json` only. [Pub workspaces](https://dart.dev/tools/pub/workspaces) hoist that file to the workspace root, so for any app that is a workspace member the name→path map comes back empty and every `flutter.plugin.platforms.tvos` plugin is **silently dropped**: empty `GeneratedPluginRegistrant`, no pods or SPM packages built, and `MissingPluginException` for every plugin call at runtime. Because discovery degrades silently (by design), there is no hint that anything went wrong until the app is running.

## Fix

- Walk up from the project directory until a `.dart_tool/package_config.json` is found — the same resolution pub itself uses.
- Resolve relative `rootUri` entries against the found file's own directory (per the package_config spec) instead of assuming the project-local location. Also accept `./`-relative URIs.

Non-workspace projects are unaffected: the file is found in the project directory on the first probe, and relative `rootUri` resolution is identical to the previous behavior in that case.

## Testing

- `flutter/bin/dart analyze lib/` — no new issues.
- `flutter/bin/dart test test/` — 270 tests pass.
- Verified end-to-end on a production monorepo app (pub workspace, 7 tvOS plugins including an FFI/cargokit one): before the fix `plugins.tvos` resolved to `[]`; after, all 7 are discovered, pods/SPM packages build, and the app runs on the Apple TV simulator with plugins working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)