### PR TITLE
fix: write FLUTTER_ROOT and flutter_export_environment.sh for pod script phases

### DIFF
--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/exceptions.dart';
 import 'package:flutter_tools/src/build_system/targets/common.dart';
 import 'package:flutter_tools/src/build_system/targets/localizations.dart';
+import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
@@ -1244,7 +1245,12 @@ class NativeTvosBundle extends Target {
         ?? project.manifest.buildNumber
         ?? '1';
 
+    final String flutterRoot = globals.fs.path.normalize(
+      globals.fs.path.join(Cache.flutterRoot!),
+    );
+
     final xcconfig = StringBuffer();
+    xcconfig.writeln('FLUTTER_ROOT=$flutterRoot');
     xcconfig.writeln('FLUTTER_APPLICATION_PATH=${project.directory.path}');
     xcconfig.writeln('FLUTTER_TARGET=$targetFile');
     xcconfig.writeln('FLUTTER_BUILD_DIR=${project.directory.childDirectory('build').path}');
@@ -1252,6 +1258,24 @@ class NativeTvosBundle extends Target {
     xcconfig.writeln('FLUTTER_BUILD_NUMBER=$buildNumber');
 
     flutterDir.childFile('Generated.xcconfig').writeAsStringSync(xcconfig.toString());
+
+    // flutter_export_environment.sh — upstream iOS/macOS write this next to
+    // Generated.xcconfig. Native-build tooling that runs inside pod script
+    // phases (e.g. cargokit) sources it to locate the Dart SDK via
+    // FLUTTER_ROOT, so tvOS must provide it too.
+    final exportEnvironment = StringBuffer()
+      ..writeln('#!/bin/sh')
+      ..writeln('# This is a generated file; do not edit or check into version control.')
+      ..writeln('export "FLUTTER_ROOT=$flutterRoot"')
+      ..writeln('export "FLUTTER_APPLICATION_PATH=${project.directory.path}"')
+      ..writeln('export "FLUTTER_TARGET=$targetFile"')
+      ..writeln('export "FLUTTER_BUILD_DIR=${project.directory.childDirectory('build').path}"')
+      ..writeln('export "FLUTTER_BUILD_NAME=$buildName"')
+      ..writeln('export "FLUTTER_BUILD_NUMBER=$buildNumber"')
+      ..writeln('export "COCOAPODS_PARALLEL_CODE_SIGN=true"');
+    flutterDir
+        .childFile('flutter_export_environment.sh')
+        .writeAsStringSync(exportEnvironment.toString());
 
     // Debug.xcconfig — always write with Pods include so CocoaPods sandbox check passes.
     flutterDir


### PR DESCRIPTION
## Problem

Upstream iOS/macOS builds write `FLUTTER_ROOT` into `Generated.xcconfig` and generate `flutter_export_environment.sh` next to it. The tvOS build does neither. Native-build tooling that runs inside CocoaPods script phases sources that file to locate the Dart SDK — [cargokit](https://github.com/irondash/cargokit) (the standard build glue for Rust-based FFI plugins) being the most common example. On tvOS its pod script phase fails with:

```
run_build_tool.sh: line 75: dart: command not found
```

because neither `FLUTTER_ROOT` nor the export script exists anywhere in the `tvos/` platform folder.

## Fix

In `_generateXcconfigs`:

- add `FLUTTER_ROOT` to `Generated.xcconfig` (from `Cache.flutterRoot`), matching upstream;
- write `tvos/Flutter/flutter_export_environment.sh` with the same variables the upstream platforms export (`FLUTTER_ROOT`, `FLUTTER_APPLICATION_PATH`, `FLUTTER_TARGET`, `FLUTTER_BUILD_DIR`, `FLUTTER_BUILD_NAME`, `FLUTTER_BUILD_NUMBER`, `COCOAPODS_PARALLEL_CODE_SIGN`).

The file is already covered by the scaffolded `tvos/.gitignore` (`Flutter/flutter_export_environment.sh`), so nothing new leaks into user VCS.

## Testing

- `flutter/bin/dart analyze lib/` — no new issues.
- `flutter/bin/dart test test/` — 270 tests pass.
- Verified end-to-end with a cargokit-based Rust FFI plugin: before the fix the pod script phase fails as above; after, cargokit locates the Dart SDK, the Rust library builds inside the Xcode build, and the app runs on the Apple TV simulator with the FFI plugin working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)