### PR TITLE
fix: bundle fragment shaders with the Metal runtime stage

### DIFF
--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -9,13 +9,18 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart' show Status;
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/build_system/depfile.dart';
 import 'package:flutter_tools/src/build_system/exceptions.dart';
+import 'package:flutter_tools/src/build_system/targets/assets.dart';
 import 'package:flutter_tools/src/build_system/targets/common.dart';
 import 'package:flutter_tools/src/build_system/targets/localizations.dart';
+import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
+import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/isolated/native_assets/dart_hook_result.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
@@ -237,21 +242,83 @@ class TvosCopyFlutterBundle extends CopyFlutterBundle {
     TvosKernelSnapshot(),
   ];
 
+  /// Mirrors [CopyFlutterBundle.build] with one change: assets are copied
+  /// with `targetPlatform: TargetPlatform.ios` instead of upstream's
+  /// hard-coded `TargetPlatform.android`.
+  ///
+  /// The target platform drives impellerc's runtime-stage flags for fragment
+  /// shaders (see `ShaderCompiler._shaderTargetsFromTargetPlatform`): android
+  /// yields SkSL/GLES/Vulkan stages, ios yields the Metal stage. Upstream can
+  /// hard-code android because on real iOS the release asset copy happens in
+  /// `ReleaseIosApplicationBundle`, which passes ios — but tvOS bundles assets
+  /// through this target, and the tvOS engine renders with Impeller/Metal, so
+  /// android-stage shaders fail at runtime with "does not contain appropriate
+  /// runtime stage data for current backend (Metal)".
+  ///
+  /// Kept in sync with upstream `CopyFlutterBundle.build`; re-mirror any
+  /// change there on a Flutter upgrade.
   @override
   Future<void> build(Environment environment) async {
     // We skip the native-assets targets for tvOS (see `dependencies`),
-    // so `native_assets.json` is never produced. Upstream
-    // CopyFlutterBundle.build() unconditionally bundles it as
-    // `NativeAssetsManifest.json` and throws PathNotFound without it.
-    // Write the canonical empty manifest first — tvOS genuinely has no
-    // Dart native assets — so the upstream copy succeeds. (In-policy:
-    // our code writes a file; flutter_tools is untouched.)
+    // so `native_assets.json` is never produced. The asset copy below
+    // bundles it as `NativeAssetsManifest.json` and throws PathNotFound
+    // without it. Write the canonical empty manifest first — tvOS genuinely
+    // has no Dart native assets — so the copy succeeds.
     final File manifest = environment.buildDir.childFile('native_assets.json');
     if (!manifest.existsSync()) {
       manifest.parent.createSync(recursive: true);
       manifest.writeAsStringSync('{"format-version":[1,0,0],"native-assets":{}}');
     }
-    await super.build(environment);
+
+    final String? buildModeEnvironment = environment.defines[kBuildMode];
+    if (buildModeEnvironment == null) {
+      throw MissingDefineException(kBuildMode, 'copy_flutter_bundle');
+    }
+    final String? flavor = environment.defines[kFlavor];
+
+    final buildMode = BuildMode.fromCliName(buildModeEnvironment);
+    environment.outputDir.createSync(recursive: true);
+
+    // Only copy the prebuilt runtimes and kernel blob in debug mode.
+    if (buildMode == BuildMode.debug) {
+      final String vmSnapshotData = environment.artifacts.getArtifactPath(
+        Artifact.vmSnapshotData,
+        mode: BuildMode.debug,
+      );
+      final String isolateSnapshotData = environment.artifacts.getArtifactPath(
+        Artifact.isolateSnapshotData,
+        mode: BuildMode.debug,
+      );
+      environment.buildDir
+          .childFile('app.dill')
+          .copySync(environment.outputDir.childFile('kernel_blob.bin').path);
+      environment.fileSystem
+          .file(vmSnapshotData)
+          .copySync(environment.outputDir.childFile('vm_snapshot_data').path);
+      environment.fileSystem
+          .file(isolateSnapshotData)
+          .copySync(environment.outputDir.childFile('isolate_snapshot_data').path);
+    }
+    final DartHooksResult dartHookResult = await DartBuild.loadHookResult(environment);
+    final Depfile assetDepfile = await copyAssets(
+      environment,
+      environment.outputDir,
+      dartHookResult: dartHookResult,
+      // tvOS rides the iOS engine (Impeller/Metal): shaders need the Metal
+      // runtime stage that only the ios shader target emits.
+      targetPlatform: TargetPlatform.ios,
+      buildMode: buildMode,
+      flavor: flavor,
+      additionalContent: <String, DevFSContent>{
+        'NativeAssetsManifest.json': DevFSFileContent(
+          environment.buildDir.childFile('native_assets.json'),
+        ),
+      },
+    );
+    environment.depFileService.writeToFile(
+      assetDepfile,
+      environment.buildDir.childFile('flutter_assets.d'),
+    );
   }
 }
 


### PR DESCRIPTION
## Problem

`TvosCopyFlutterBundle` inherits upstream `CopyFlutterBundle.build`, which hard-codes `targetPlatform: TargetPlatform.android` for `copyAssets`. The target platform drives impellerc's runtime-stage flags (`ShaderCompiler._shaderTargetsFromTargetPlatform`): android yields SkSL/GLES/Vulkan stages, ios yields the Metal stage. Upstream can hard-code android because on real iOS the release asset copy happens in `ReleaseIosApplicationBundle`, which passes ios — but tvOS bundles assets through `CopyFlutterBundle` in every build mode, and the tvOS engine renders with Impeller/Metal.

The result: every fragment shader in a tvOS app bundle fails at load time with

```
Exception: Asset '....frag' does not contain appropriate runtime stage data for current backend (Metal).
Found stages: SkSL OpenGLES OpenGLES3 Vulkan
```

As a side effect, the build also emits impellerc SkSL-compilation warnings for shaders that can never target SkSL (e.g. ones using `fwidth` or array initializers), even though that stage is useless on tvOS.

## Fix

`TvosCopyFlutterBundle.build` now mirrors upstream `CopyFlutterBundle.build` (same maintenance contract as `TvosKernelSnapshot`: re-mirror on Flutter upgrades) with one change — `copyAssets` receives `targetPlatform: TargetPlatform.ios`, so shaders are bundled with the Metal runtime stage. The existing empty-`native_assets.json` shim is folded into the mirrored body.

## Testing

- `flutter/bin/dart analyze lib/` — no new issues vs unmodified `main`.
- `flutter/bin/dart test` — identical results with and without the change (the failures in my environment reproduce byte-for-byte on unmodified `main`; unrelated).
- End-to-end with an app using many fragment shaders: before, every `FragmentProgram.fromAsset` failed with the error above; after, the bundled `.frag` assets contain the Metal stage (MSL source present, GLES/Vulkan stages absent) and load correctly on the Apple TV simulator. The spurious SkSL impellerc warnings are gone as well.

Note: touches the same import block in `lib/build_targets/application.dart` as #33, so whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
