### PR TITLE
Skip plugin registration with a clear message when the engine isn't running (physical tvOS debug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to flutter-tvos will be documented here.
      Do not add a version heading or bump pubspec.yaml — maintainers assign
      versions at release time. -->
 
+### Fixed
+- **Debug builds launched outside `flutter-tvos run` on a physical Apple TV no
+  longer crash during plugin registration.** The debug engine refuses to start
+  without an attached debugger, so the plugin registry hands back nil
+  registrars — which crashed the generated registrant with an unsymbolized
+  SIGSEGV blaming whichever plugin registered first. The registrant now probes
+  the registry once, logs a clear "engine is not running" message explaining
+  the `flutter-tvos run` requirement, and skips registration instead of
+  crashing. (#37)
+
 ## [1.4.0] — 2026-07-11
 
 Ships the last of the App Store submission blockers: the engine artifact is now

--- a/doc/debug-app.md
+++ b/doc/debug-app.md
@@ -103,6 +103,12 @@ xcrun devicectl device process launch --console \
 
 `<device_id>` is the UUID shown by `xcrun devicectl list devices`. The `--console` flag attaches stdout/stderr to your terminal session.
 
+> **Note:** standalone launches like this only work for **profile and release**
+> builds. A debug build launched outside `flutter-tvos run` cannot start its
+> engine (the debug engine requires an attached debugger) — plugin
+> registration is skipped and a `[GeneratedPluginRegistrant]` message
+> explaining this appears in the console.
+
 ## Other Resources
 
 - [Flutter debugging documentation](https://docs.flutter.dev/testing/debugging) — core Dart and Flutter debugging concepts that apply equally to tvOS.

--- a/lib/tvos_plugins.dart
+++ b/lib/tvos_plugins.dart
@@ -36,6 +36,13 @@ import {{name}}
 {{/methodChannelPlugins}}
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  // The registry returns nil registrars when the Flutter engine is not
+  // running (on a physical Apple TV the debug engine requires an attached
+  // debugger). Nil crashes plugin registration, so bail out loudly.
+  guard registry.registrar(forPlugin: "__flutter_tvos_engine_probe__") != nil else {
+    NSLog("[GeneratedPluginRegistrant] Flutter engine is not running; skipping plugin registration. Debug builds on a physical Apple TV must be launched via 'flutter-tvos run' (the debug engine requires an attached debugger).")
+    return
+  }
   {{#methodChannelPlugins}}
   {{class}}.register(with: registry.registrar(forPlugin: "{{class}}"))
 {{/methodChannelPlugins}}
@@ -677,6 +684,25 @@ Future<void> ensureReadyForTvosTooling(FlutterProject project) async {
       }
     }
 
+    // A nil registrar means the engine never started (on a physical Apple TV
+    // the debug engine requires an attached debugger — see
+    // doc/architecture.md). Bridged into a Swift plugin's nonnull parameter,
+    // that nil crashes registration with an unsymbolized SIGSEGV blaming the
+    // first plugin. Probe once with a synthetic key (a real plugin key would
+    // trip the engine's duplicate-registration assert) and bail out loudly.
+    final engineGuard = registrations.isEmpty
+        ? ''
+        : '  // The registry returns nil registrars when the Flutter engine is not\n'
+            '  // running (on a physical Apple TV the debug engine requires an attached\n'
+            '  // debugger). Nil crashes Swift plugin registration, so bail out loudly.\n'
+            '  if ([registry registrarForPlugin:@"__flutter_tvos_engine_probe__"] == nil) {\n'
+            '    NSLog(@"[GeneratedPluginRegistrant] Flutter engine is not running; skipping "\n'
+            '          @"plugin registration. Debug builds on a physical Apple TV must be "\n'
+            '          @"launched via \'flutter-tvos run\' (the debug engine requires an "\n'
+            '          @"attached debugger).");\n'
+            '    return;\n'
+            '  }\n';
+
     // Force-reference the C symbols of any statically-linked (SPM) FFI plugin
     // so the linker keeps them in the Runner binary; empty for the common case.
     final List<String> ffiForcedSymbols =
@@ -721,6 +747,7 @@ Future<void> ensureReadyForTvosTooling(FlutterProject project) async {
       '@implementation GeneratedPluginRegistrant\n'
       '\n'
       '+ (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {\n'
+      '$engineGuard'
       '$registrations'
       '$ffiForcedBody'
       '}\n'

--- a/test/general/tvos_plugins_test.dart
+++ b/test/general/tvos_plugins_test.dart
@@ -1087,6 +1087,108 @@ $symbolsYaml
     );
   });
 
+  group('engine guard in GeneratedPluginRegistrant.m', () {
+    // Seeds an app with a single method-channel plugin `gadget` plus the
+    // tvos/Runner/ directory the ObjC registrant is written into.
+    FlutterProject seedMethodChannelProject() {
+      final Directory projectDir = fileSystem.directory('/p')..createSync();
+      projectDir.childDirectory('tvos').childDirectory('Runner').createSync(recursive: true);
+      projectDir.childFile('pubspec.yaml').writeAsStringSync('name: app\n');
+
+      final Directory pkgDir = fileSystem.directory('/pubcache/gadget')
+        ..createSync(recursive: true);
+      pkgDir.childFile('pubspec.yaml').writeAsStringSync('''
+name: gadget
+flutter:
+  plugin:
+    platforms:
+      tvos:
+        pluginClass: GadgetPlugin
+''');
+      final Directory tvosDir = pkgDir.childDirectory('tvos')..createSync();
+      tvosDir.childFile('gadget.podspec').writeAsStringSync('# podspec');
+
+      fileSystem.directory('/p/.dart_tool').childFile('package_config.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          json.encode(<String, dynamic>{
+            'packages': <Map<String, String>>[
+              <String, String>{
+                'name': 'gadget',
+                'rootUri': 'file:///pubcache/gadget',
+              },
+            ],
+          }),
+        );
+      projectDir.childFile('.flutter-plugins-dependencies').writeAsStringSync(
+        json.encode(<String, dynamic>{
+          'dependencyGraph': <Map<String, String>>[
+            <String, String>{'name': 'gadget'},
+          ],
+        }),
+      );
+      return FlutterProject.fromDirectory(projectDir);
+    }
+
+    String registrantOf(FlutterProject project) => project.directory
+        .childDirectory('tvos')
+        .childDirectory('Runner')
+        .childFile('GeneratedPluginRegistrant.m')
+        .readAsStringSync();
+
+    testUsingContext(
+      'guards registration behind an engine probe when method-channel plugins exist',
+      () async {
+        final FlutterProject project = seedMethodChannelProject();
+        await ensureReadyForTvosTooling(project);
+
+        final String m = registrantOf(project);
+        expect(m, contains('registrarForPlugin:@"__flutter_tvos_engine_probe__"'));
+        expect(m, contains('Flutter engine is not running'));
+        // The guard must run before any plugin registration.
+        expect(
+          m.indexOf('__flutter_tvos_engine_probe__'),
+          lessThan(m.indexOf('[GadgetPlugin registerWithRegistrar:')),
+          reason: 'engine probe must precede the first registration',
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+
+    testUsingContext(
+      'omits the guard when there are no method-channel plugins',
+      () async {
+        final Directory projectDir = fileSystem.directory('/p')..createSync();
+        projectDir
+            .childDirectory('tvos')
+            .childDirectory('Runner')
+            .createSync(recursive: true);
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: app\n');
+        fileSystem.directory('/p/.dart_tool').childFile('package_config.json')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(json.encode(<String, dynamic>{'packages': <dynamic>[]}));
+        projectDir.childFile('.flutter-plugins-dependencies').writeAsStringSync(
+          json.encode(<String, dynamic>{'dependencyGraph': <dynamic>[]}),
+        );
+
+        final FlutterProject project = FlutterProject.fromDirectory(projectDir);
+        await ensureReadyForTvosTooling(project);
+
+        expect(
+          registrantOf(project),
+          isNot(contains('__flutter_tvos_engine_probe__')),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+  });
+
   group('TvosPlugin.ffiSymbols', () {
     testWithoutContext('defaults to an empty list', () {
       final plugin = TvosPlugin(name: 'm', path: '/p', pluginClass: 'MPlugin');


### PR DESCRIPTION
First off, thanks for flutter-tvos — got a Flutter app building, running, and debuggable on a real Apple TV with it this week.

Sharing one rough edge that cost me a debugging session, in case a small change helps the next person.

## Why

`doc/architecture.md` notes the debug engine only starts with a debugger attached (`ptrace_check.cc`), which `flutter-tvos run` handles via its lldb/Xcode attach flow — makes sense, and it works for me. The snag is how it fails when a debug build is launched *outside* that flow: the engine never comes up, the generated registrant passes a nil registrar into the first Swift plugin, and the app SIGSEGVs with a stack that blames that plugin — nothing pointing at the real cause. I chased a phantom plugin bug for a while before landing on the ptrace note. (The `doc/debug-app.md` logging section shows a bare `devicectl … launch`, which is an easy way to hit this.)

This adds a one-time probe: if the registry hands back a nil registrar, log a clear message and skip registration instead of crashing.

## Repro

1. `flutter-tvos create demo && cd demo`, add one Swift plugin (e.g. `connectivity_plus_tvos`) so the registrant has an entry
2. set `DEVELOPMENT_TEAM`, `flutter-tvos build tvos --debug`, install on a physical Apple TV
3. `xcrun devicectl device process launch --console --device <id> <bundle id>`

## Before

```
EXC_BAD_ACCESS (SIGSEGV) at 0x0
  libswiftCore.dylib   swift_getObjectType
  Runner.debug.dylib   static ConnectivityPlusPlugin.register(with:)
  Runner.debug.dylib   +[GeneratedPluginRegistrant registerWithRegistry:]
```
(no console output — crash blames whichever plugin is first)

## After

```
[GeneratedPluginRegistrant] Flutter engine is not running; skipping plugin
registration. Debug builds on a physical Apple TV must be launched via
'flutter-tvos run' (the debug engine requires an attached debugger).
```
No crash. Verified on an Apple TV 4K (tvOS 26.5). Guard is emitted into both the ObjC and Swift registrants and only when method-channel plugins exist; `dart analyze` clean and `dart test test/` green (added two cases). A deeper fix in the engine (printing the ptrace refusal itself) would make this unnecessary — flagging in case that's preferable.
