### PR TITLE
Stop claiming flutter_tvos provides Siri Remote navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to flutter-tvos will be documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- `flutter_tvos` README no longer claims the package provides Siri Remote
+  navigation. The engine does: an app using only `Focus`, `FocusTraversal`,
+  `Shortcuts` and standard focusable widgets responds to the remote without
+  depending on the package at all. The package adds tuning (key repeat,
+  touchpad dead zone, swipe thresholds), the analog touch stream and swipe
+  events. Raw touch forwarding is the one feature that genuinely requires it,
+  because the engine gates it behind the `configure` handshake that
+  `TvRemoteController.init()` performs.
+
 ## [1.4.3] - 2026-07-25
 
 ### Changed

--- a/packages/flutter_tvos/README.md
+++ b/packages/flutter_tvos/README.md
@@ -11,9 +11,10 @@ Part of the [flutter-tvos](https://fluttertv.dev) project — an open-source Flu
 - Check device capabilities: 4K, HDR, multi-user support
 - Get display resolution
 - **Synchronous API** — powered by dart:ffi, zero async overhead
-- **Siri Remote support** — swipes and buttons drive Flutter's standard
-  focus system, with raw-touch and high-level swipe listeners for custom
-  handling (see [Remote Control](#remote-control-siri-remote))
+- **Siri Remote extras** — tuning for how the remote maps to keys (repeat
+  speed, touchpad dead zone, swipe thresholds), plus raw-touch and
+  high-level swipe listeners. Basic focus navigation needs no package —
+  the engine provides it (see [Remote Control](#remote-control-siri-remote))
 
 ## Getting Started
 
@@ -66,15 +67,32 @@ Widget build(BuildContext context) {
 
 ## Remote Control (Siri Remote)
 
-`flutter_tvos` wires the Apple TV remote to Flutter's standard focus
+The **tvOS engine** wires the Apple TV remote to Flutter's standard focus
 system. Swipes and button presses become keyboard events
 (`arrowLeft/Right/Up/Down`, `select`, etc.) which flow through
 `Focus`/`Shortcuts`/`Actions` exactly like arrow keys on a physical
 keyboard would.
 
-Basic remote navigation works through Flutter's normal key/focus system. If
-your app only uses `Focus`, `Shortcuts`, `Actions`, buttons, lists, and other
-standard focusable widgets, no Dart listener setup is required.
+### Do you need this package for remote navigation?
+
+**No.** Remote navigation is delivered by the engine, not by this package. An
+app that only uses `Focus`, `FocusTraversal`, `Shortcuts`, `Actions`, buttons,
+lists and other standard focusable widgets responds to the Siri Remote with
+`flutter_tvos` not even in its `pubspec.yaml`. Everything under "What works out
+of the box" below is engine-side and needs no Dart dependency.
+
+Reach for this package when you want to:
+
+- **tune** how the remote is translated into keys — repeat speed, touchpad
+  dead zone, swipe thresholds (see [Tuning](#tuning));
+- consume the **analog touchpad** as coordinates rather than keys
+  (`addRawListener`);
+- consume **swipes** as direction + magnitude events (`addSwipeListener`).
+
+The raw touch stream is the one feature that genuinely requires the package:
+the engine holds touch forwarding back until Dart completes the `configure`
+handshake, which `TvRemoteController.init()` performs. Key events are not
+gated that way and flow regardless.
 
 Call `TvRemoteController.instance.init()` once in `main()` when you use
 `TvRemoteController` APIs such as `config`, `addRawListener`, or
@@ -92,6 +110,8 @@ void main() {
 ```
 
 ### What works out of the box
+
+All of the following is engine-side — it works with or without this package:
 
 - Swipes Up/Down/Left/Right on Siri Remote → arrow keys
 - Select button → `LogicalKeyboardKey.enter` — activates focused


### PR DESCRIPTION
Documentation-only. No code, no API change.

## The problem

`packages/flutter_tvos/README.md` opened with:

> `flutter_tvos` wires the Apple TV remote to Flutter's standard focus system.

The **engine** does that. Which is why an app with no dependency on this package still responds to the remote — and why the claim is worth correcting rather than softening.

## How this was established

Not by reading code. A stock-Flutter tvOS app with **no `flutter_tvos` in its pubspec**, using only `FocusableActionDetector`, was built and run on a physical Apple TV 4K with a real Siri Remote:

- Focus traversed on arrows and activated on Select
- `HardwareKeyboard` received 24 events, 12 Down / 12 Up, zero exceptions under a debug build with asserts on
- Physical codes matched the simulator exactly: `0x7004f` / `0x70051` / `0x70050`, Select→Enter `0x70028`

The mechanism: `KeyEventManager.handleRawKeyMessage` latches `rawKeyData` transit mode on the first legacy `flutter/keyevent` message and converts `RawKeyEvent`s into `KeyEvent`s. So the legacy channel alone already drives `HardwareKeyboard`, `Focus`, `FocusTraversal` and `Shortcuts`.

## What changed

- Opening claim corrected — the engine provides remote navigation.
- New **"Do you need this package for remote navigation?"** section answering **no**, listing what the package is genuinely for: tuning key synthesis (`dpadDeadZone`, `keyRepeatInitialDelay`/`Interval`, swipe thresholds), the analog touch stream, and swipe events.
- "What works out of the box" marked engine-side.
- Features bullet: "Siri Remote support" → "Siri Remote extras" (the former implies the package supplies the input).

One exception is stated explicitly rather than glossed: **raw touch forwarding does require the package**, because the engine gates it behind the `configure` handshake `TvRemoteController.init()` performs. Key events and native swipe→arrow synthesis are not gated and flow regardless.

## Verification

- `dart analyze lib/` — exit 0 (135 pre-existing infos, non-gating)
- CLI tests — 297 pass
- `flutter_tvos` package tests — 103 pass
- Physical Apple TV 4K + real Siri Remote, as above

## Note for the release

`packages/flutter_tvos/CHANGELOG.md` is untouched. It uses assigned version headings rather than an `[Unreleased]` section, and per the branching model maintainers assign versions at release — so this needs a package CHANGELOG line when the package is next published to pub.dev. The repo-level `[Unreleased]` entry is included here.
