### PR TITLE
Ignore docs/licensing/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ packages/flutter_tvos/build/
 # (CocoaPods expands local-path pods into the lock). Regenerated per
 # developer by `pod install`.
 packages/flutter_tvos/example/tvos/Podfile.lock
+
+# Licensing package — commercial negotiating position, never publish (repo is PUBLIC)
+docs/licensing/


### PR DESCRIPTION
One line. This repo is public and `docs/` is tracked, so the licensing package sitting untracked inside it — source licence, CLA, NDA, the § 8 UrhG co-authors agreement, a risks-accepted memo — is one `git add docs/` away from being published, and that cannot be undone once GitHub has cached it and forks have diverged.

Nothing from it is in history. This only closes the accident.

Found while preparing #50, where a broad `git add -A docs` swept in eighteen unrelated untracked files and I had to back them out. Same root cause, so worth fixing rather than remembering.