### PR TITLE
Fix `flutter-tvos create .` naming the project "."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to flutter-tvos will be documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- `flutter-tvos create --platforms=tvos .` no longer names the project `.`.
+  The command derived the package name from the raw output-directory argument,
+  so a `.` target produced `name: .` in `pubspec.yaml` (and a `.App` widget
+  class). It now uses the same resolution as stock `flutter create`:
+  `--project-name` if given, else the `name` of an existing `pubspec.yaml`,
+  else the basename of the *normalized absolute* directory path — and the
+  result is validated, so a directory like `my-tv-app` fails with
+  "not a valid Dart package name" instead of scaffolding a broken project.
+
 ## [1.4.4] - 2026-07-31
 
 - Engine artifacts updated to `v1.0.2-flutter3.44.8` (origin-signed for ITMS-91065

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to flutter-tvos will be documented here.
   result is validated, so a directory like `my-tv-app` fails with
   "not a valid Dart package name" instead of scaffolding a broken project.
 
+  Without `--platforms=tvos` the damage was quieter but still there: upstream
+  `flutter create` resolved the Dart package name correctly, while the `tvos/`
+  runner we add on top got `CFBundleName = .` and a bundle identifier that
+  collapsed to a bare `com.example` — shared by every project created that way.
+  If you generated a project with `create .`, check
+  `tvos/Runner/Info.plist` and `PRODUCT_BUNDLE_IDENTIFIER` in
+  `tvos/Runner.xcodeproj/project.pbxproj`.
+
 ## [1.4.4] - 2026-07-31
 
 - Engine artifacts updated to `v1.0.2-flutter3.44.8` (origin-signed for ITMS-91065

--- a/lib/commands/create.dart
+++ b/lib/commands/create.dart
@@ -30,9 +30,15 @@ class TvosCreateCommand extends CreateCommand {
     // below reads `rest.first` before delegating to `super.runCommand()`, so
     // validate up front.
     validateOutputDirectoryArg();
-    final String projectDirPath = argResults!.rest.first;
-    final String name =
-        stringArg('project-name') ?? globals.fs.path.basename(projectDirPath);
+    // Use the inherited `CreateBase` getters rather than reading
+    // `argResults!.rest.first` raw: `projectDirPath` is normalized and
+    // absolute (so `flutter-tvos create .` resolves to the current directory
+    // instead of yielding the literal "."), and `projectName` mirrors stock
+    // `flutter create` — explicit `--project-name`, else the `name` of an
+    // existing pubspec.yaml, else the directory basename — and validates the
+    // result is a legal Dart package name.
+    final String projectPath = projectDirPath;
+    final String name = projectName;
     final String templateType = stringArg('template') ?? 'app';
 
     // tvOS-only app: build the shared scaffold + tvos/ ourselves. We do
@@ -41,8 +47,8 @@ class TvosCreateCommand extends CreateCommand {
     // then stripped — the project is tvOS-only by construction.
     if (boolArg('tvos-only') && templateType != 'plugin') {
       globals.logger.printStatus('Generating tvOS-only project...');
-      TvosAppScaffold(globals.fs).write(projectDirPath, name);
-      await _renderTvosRunner(projectDirPath, name);
+      TvosAppScaffold(globals.fs).write(projectPath, name);
+      await _renderTvosRunner(projectPath, name);
       globals.logger.printStatus(
         'Created tvOS-only project (shared app + tvos/, no other platforms).',
       );
@@ -56,9 +62,9 @@ class TvosCreateCommand extends CreateCommand {
       return exitCode;
     }
     if (templateType == 'plugin') {
-      return _createPlugin(projectDirPath, name);
+      return _createPlugin(projectPath, name);
     }
-    return _createApp(projectDirPath, name);
+    return _createApp(projectPath, name);
   }
 
   Future<FlutterCommandResult> _createApp(String projectDirPath, String name) async {

--- a/test/general/tvos_create_test.dart
+++ b/test/general/tvos_create_test.dart
@@ -1,0 +1,117 @@
+// Copyright 2026 The FlutterTV Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tvos/commands/create.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+import '../src/test_flutter_command_runner.dart';
+
+void main() {
+  late MemoryFileSystem fileSystem;
+  late FakeProcessManager processManager;
+
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    processManager = FakeProcessManager.any();
+    Cache.flutterRoot = '/flutter';
+    fileSystem.directory('/flutter').createSync(recursive: true);
+  });
+
+  group('TvosCreateCommand project name', () {
+    testUsingContext(
+      'derives the name from the current directory for `create .`',
+      () async {
+        final Directory projectDir = fileSystem.directory('/home/my_tv_app')
+          ..createSync(recursive: true);
+        fileSystem.currentDirectory = projectDir;
+
+        await createTestCommandRunner(
+          TvosCreateCommand(verboseHelp: false),
+        ).run(<String>['create', '--tvos-only', '--no-pub', '.']);
+
+        expect(
+          projectDir.childFile('pubspec.yaml').readAsStringSync(),
+          contains('name: my_tv_app'),
+        );
+        expect(
+          projectDir.childDirectory('lib').childFile('main.dart').readAsStringSync(),
+          contains('MyTvAppApp'),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+
+    testUsingContext(
+      'derives the name from the target directory basename',
+      () async {
+        await createTestCommandRunner(
+          TvosCreateCommand(verboseHelp: false),
+        ).run(<String>['create', '--tvos-only', '--no-pub', '/home/other_app']);
+
+        expect(
+          fileSystem.file('/home/other_app/pubspec.yaml').readAsStringSync(),
+          contains('name: other_app'),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+
+    testUsingContext(
+      '--project-name still wins over the directory name',
+      () async {
+        await createTestCommandRunner(TvosCreateCommand(verboseHelp: false)).run(<String>[
+          'create',
+          '--tvos-only',
+          '--no-pub',
+          '--project-name=chosen_name',
+          '/home/ignored_dir',
+        ]);
+
+        expect(
+          fileSystem.file('/home/ignored_dir/pubspec.yaml').readAsStringSync(),
+          contains('name: chosen_name'),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+
+    testUsingContext(
+      'rejects a directory name that is not a valid Dart package name',
+      () async {
+        final Directory projectDir = fileSystem.directory('/home/my-tv-app')
+          ..createSync(recursive: true);
+        fileSystem.currentDirectory = projectDir;
+
+        await expectLater(
+          createTestCommandRunner(
+            TvosCreateCommand(verboseHelp: false),
+          ).run(<String>['create', '--tvos-only', '--no-pub', '.']),
+          throwsToolExit(message: 'is not a valid Dart package name'),
+        );
+        expect(projectDir.childFile('pubspec.yaml').existsSync(), isFalse);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+  });
+}

--- a/test/general/tvos_create_test.dart
+++ b/test/general/tvos_create_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tvos/commands/create.dart';
 
@@ -11,6 +12,12 @@ import '../src/common.dart';
 import '../src/context.dart';
 import '../src/test_flutter_command_runner.dart';
 
+// NOTE: these tests spell the flag `--tvos-only`, never `--platforms=tvos`.
+// Users type the latter; `expandTvosPlatformArgs` (executable.dart) rewrites it
+// to the former before the arg parser sees it, because upstream's `--platforms`
+// enum rejects `tvos`. `createTestCommandRunner` hands argv straight to the
+// command and never runs that shim, so `--platforms=tvos` fails here with
+// '"tvos" is not an allowed value for option "platforms"'.
 void main() {
   late MemoryFileSystem fileSystem;
   late FakeProcessManager processManager;
@@ -110,6 +117,72 @@ void main() {
       },
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+  });
+
+  // The `--tvos-only` tests above return before `super.runCommand()`. Without
+  // that flag the command delegates to upstream `flutter create` first, and
+  // upstream resolves the *Dart* package name itself — so pre-fix that path was
+  // split-brain rather than uniformly broken: a correctly named Dart project
+  // wrapping a `tvos/` runner named `.` (`CFBundleName = .`, and a bundle
+  // identifier that collapsed to a bare `com.example`, shared by every project
+  // created this way). This test pins the runner side of that.
+  //
+  // It needs the real template tree (`renderMerged` reads
+  // `templates/template_manifest.json` from the Flutter root), which a
+  // MemoryFileSystem does not have — hence the local file system and a temp
+  // directory. It runs against the vendored `flutter/` checkout, the same one
+  // `flutter/bin/dart test` is invoked from, so no extra setup is required.
+  group('TvosCreateCommand standard path', () {
+    late LocalFileSystem localFileSystem;
+    late Directory tempDir;
+    late String originalCwd;
+
+    setUp(() {
+      localFileSystem = LocalFileSystem.test(signals: Signals.test());
+      originalCwd = localFileSystem.currentDirectory.path;
+      // Absolute, and resolved before the cwd moves below.
+      Cache.flutterRoot = localFileSystem.path.join(originalCwd, 'flutter');
+      tempDir = localFileSystem.systemTempDirectory.createTempSync('flutter_tvos_create_test.');
+    });
+
+    tearDown(() {
+      // `LocalFileSystem.currentDirectory` is process-global; always put it back.
+      localFileSystem.currentDirectory = originalCwd;
+      tempDir.deleteSync(recursive: true);
+    });
+
+    testUsingContext(
+      'names the tvOS runner after the directory for `create .`',
+      () async {
+        final Directory projectDir = tempDir.childDirectory('my_tv_app')..createSync();
+        localFileSystem.currentDirectory = projectDir;
+
+        await createTestCommandRunner(
+          TvosCreateCommand(verboseHelp: false),
+        ).run(<String>['create', '--no-pub', '--platforms=ios', '.']);
+
+        // Upstream resolves this one correctly even without the fix.
+        expect(
+          projectDir.childFile('pubspec.yaml').readAsLinesSync().first,
+          'name: my_tv_app',
+        );
+
+        // These two came from our `name` and were `.` before the fix.
+        final Directory runner = projectDir.childDirectory('tvos');
+        expect(
+          runner.childDirectory('Runner').childFile('Info.plist').readAsStringSync(),
+          contains('<string>my_tv_app</string>'),
+        );
+        expect(
+          runner.childDirectory('Runner.xcodeproj').childFile('project.pbxproj').readAsStringSync(),
+          contains('PRODUCT_BUNDLE_IDENTIFIER = com.example.myTvApp;'),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => localFileSystem,
         ProcessManager: () => processManager,
       },
     );

--- a/test/general/tvos_create_test.dart
+++ b/test/general/tvos_create_test.dart
@@ -4,9 +4,13 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/dart/package_map.dart';
+import 'package:flutter_tools/src/template.dart';
 import 'package:flutter_tvos/commands/create.dart';
+import 'package:package_config/package_config.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -133,8 +137,17 @@ void main() {
   // It needs the real template tree (`renderMerged` reads
   // `templates/template_manifest.json` from the Flutter root), which a
   // MemoryFileSystem does not have — hence the local file system and a temp
-  // directory. It runs against the vendored `flutter/` checkout, the same one
-  // `flutter/bin/dart test` is invoked from, so no extra setup is required.
+  // directory, running against the vendored `flutter/` checkout.
+  //
+  // The one piece of the SDK it must NOT depend on is
+  // `flutter/packages/flutter_tools/.dart_tool/package_config.json`, which
+  // upstream's `TemplatePathProvider.imageDirectory` reads to locate
+  // `flutter_template_images`. That file only exists once the Flutter tool has
+  // bootstrapped itself, which a developer checkout has done and a fresh CI
+  // clone has not — so depending on it makes the test pass locally and fail in
+  // CI. `_LocalPackageConfigTemplatePathProvider` below resolves the same
+  // package from *our* `.dart_tool/package_config.json` instead, which
+  // `dart pub get` always produces (the suite cannot run without it).
   group('TvosCreateCommand standard path', () {
     late LocalFileSystem localFileSystem;
     late Directory tempDir;
@@ -184,7 +197,38 @@ void main() {
       overrides: <Type, Generator>{
         FileSystem: () => localFileSystem,
         ProcessManager: () => processManager,
+        TemplatePathProvider: () =>
+            _LocalPackageConfigTemplatePathProvider(originalCwd),
       },
     );
   });
+}
+
+/// A [TemplatePathProvider] that resolves `flutter_template_images` from this
+/// package's own `.dart_tool/package_config.json` rather than the Flutter
+/// tool's, which is only present in a bootstrapped SDK checkout.
+///
+/// Everything else — including the template directories themselves — comes
+/// from the real provider.
+class _LocalPackageConfigTemplatePathProvider extends TemplatePathProvider {
+  const _LocalPackageConfigTemplatePathProvider(this.packageRoot);
+
+  /// Root of this package, i.e. the directory holding `.dart_tool/`.
+  final String packageRoot;
+
+  @override
+  Future<Directory> imageDirectory(String? name, FileSystem fileSystem, Logger logger) async {
+    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
+      fileSystem.file(
+        fileSystem.path.join(packageRoot, '.dart_tool', 'package_config.json'),
+      ),
+      logger: logger,
+    );
+    final Uri? imagePackageLibDir = packageConfig['flutter_template_images']?.packageUriRoot;
+    final Directory templateDirectory = fileSystem
+        .directory(imagePackageLibDir)
+        .parent
+        .childDirectory('templates');
+    return name == null ? templateDirectory : templateDirectory.childDirectory(name);
+  }
 }


### PR DESCRIPTION
## Problem

```bash
flutter-tvos create --platforms=tvos .
```

scaffolds a project literally named `.` — `name: .` in `pubspec.yaml`, a `.App`
widget class in `lib/main.dart`, and a bundle identifier built from `.`. The
result doesn't `pub get`, let alone build.

## Cause

`TvosCreateCommand.runCommand` derived both values from the raw argument:

```dart
final String projectDirPath = argResults!.rest.first;                  // "."
final String name = stringArg('project-name')
    ?? globals.fs.path.basename(projectDirPath);                       // "."
```

`basename(".")` is `"."`. Stock `flutter create` avoids this because
`CreateBase` already exposes a `projectDirPath` getter (normalized + absolute)
and a `projectName` getter with the full resolution chain and name validation —
this command just wasn't using them.

## Fix

Use the inherited getters. Behaviour now matches stock `flutter create`:

- `.` resolves to the containing directory's name.
- Re-running inside an existing project reuses that project's `pubspec.yaml`
  `name` instead of the folder name.
- `--project-name` still takes precedence.
- An illegal package name (e.g. a `my-tv-app` directory) exits with
  *"my-tv-app" is not a valid Dart package name* instead of writing a broken
  project.

## Tests

New `test/general/tvos_create_test.dart` covers all four cases. Verified they
fail against the previous code (`Actual: 'name: .\n'`) and pass with the fix.
Full suite: 342 passing.