### PR TITLE
Mirror main to dev automatically instead of by pull request

### DIFF
--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -1,0 +1,79 @@
+name: Sync main
+
+# main mirrors dev. Nothing lands on main directly and there is no dev -> main
+# pull request: whatever is on dev, once its tests pass, is what main becomes.
+#
+# The dev -> main PR is what used to cause the recurring conflict. main required
+# a linear history while dev's is not linear (it carries merge commits), so such
+# a PR could only ever be squashed — and a squash writes a commit onto main that
+# exists nowhere in dev's history. main was then 1 ahead, the branches had
+# genuinely diverged, and the next round conflicted on the version and CHANGELOG
+# files. Fast-forwarding cannot produce that state: main becomes literally dev's
+# commit, so the branches can never drift apart in the first place.
+#
+# required_linear_history is therefore off on main now. A mirror cannot enforce a
+# stricter history shape than the branch it mirrors, and keeping it on is what
+# forced the squash. main is still protected against force pushes and deletion.
+on:
+  workflow_run:
+    workflows: [Test]
+    branches: [dev]
+    types: [completed]
+  # Recovery hatch: re-run the sync without pushing anything to dev.
+  workflow_dispatch:
+
+# Two pushes to dev in quick succession would otherwise race to move main, and
+# the loser fails on a stale ref rather than doing anything useful.
+concurrency:
+  group: sync-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # Only mirror a green dev. Without this main would inherit whatever broke,
+    # which is the one thing the release branch must not do. workflow_dispatch
+    # carries no conclusion, so allow it through explicitly.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          # A shallow clone cannot prove the push is a fast-forward, so the
+          # push below would be rejected for reasons that read like a
+          # permissions problem.
+          fetch-depth: 0
+
+      - name: Fast-forward main to dev
+        run: |
+          set -euo pipefail
+          DEV_SHA=$(git rev-parse HEAD)
+          git fetch --no-tags origin main
+          MAIN_SHA=$(git rev-parse origin/main)
+
+          if [ "$DEV_SHA" = "$MAIN_SHA" ]; then
+            echo "main is already at $DEV_SHA — nothing to do."
+            exit 0
+          fi
+
+          # Refuse to move main backwards. If dev does not contain main's tip,
+          # something landed on main directly and the mirror invariant is
+          # already broken; a push here would either fail or, with force, throw
+          # that commit away. Fail loudly and let a human look.
+          if ! git merge-base --is-ancestor "$MAIN_SHA" "$DEV_SHA"; then
+            echo "::error::main ($MAIN_SHA) is not an ancestor of dev ($DEV_SHA)."
+            echo "Something was committed to main outside this workflow, so the"
+            echo "branches have diverged and this is no longer a fast-forward."
+            echo "Reconcile them by hand before the mirror can resume."
+            exit 1
+          fi
+
+          echo "Fast-forwarding main: $MAIN_SHA -> $DEV_SHA"
+          # Deliberately not --force: a plain push is itself the guarantee that
+          # this is a fast-forward, so the check above can never be the only
+          # thing standing between a mistake and a rewritten main.
+          git push origin "$DEV_SHA:refs/heads/main"


### PR DESCRIPTION
`main` becomes whatever `dev` is, once `dev` is green. No more `dev` → `main` pull request.

## Why that PR kept conflicting

It wasn't redundant bookkeeping — it was generating the conflicts.

`main` required a linear history. `dev`'s history is **not** linear; it carries four merge commits:

```
b322013  Merge pull request #61 from fluttertv/chore/sync-main-into-dev
b7ca67a  Merge main into dev (1.5.1 release files)
8635711  Merge pull request #60 from fluttertv/chore/flutter-3.44.9
0e32f18  Merge main into dev
```

So the `dev` → `main` PR could only ever be **squashed** — a merge commit was rejected outright. And a squash writes a commit onto `main` that exists in no part of `dev`'s history. `main` was then one ahead, the two branches had genuinely diverged, and the next round conflicted on the version and `CHANGELOG` files. Every time. The documented fix for it (merge `main` back into `dev`, resolve `--ours` on the version files) is visible in two of those four merge commits above.

A fast-forward cannot reach that state. `main` becomes *literally* `dev`'s commit, so there is nothing to diverge.

## The workflow

Fires on the **Test** workflow completing successfully on `dev`, so a red `dev` is never mirrored to the release branch. `workflow_dispatch` is there as a manual recovery hatch.

Three deliberate choices:

- **The push is not forced.** Git itself is then the thing guaranteeing the fast-forward, rather than the ancestry check in the script being the only thing between a mistake and a rewritten `main`.
- **The ancestry check runs anyway**, so if someone has pushed to `main` directly the job fails with a message naming that cause, instead of a bare rejected-push error.
- **`fetch-depth: 0`** — a shallow clone cannot prove a fast-forward, and the resulting rejection reads like a permissions problem.

`concurrency: sync-main` keeps two quick merges to `dev` from racing.

## Settings changed on `main`

Both existed only to police a PR that no longer happens:

| setting | before | after | why |
|---|---|---|---|
| push allowlist | one user | *(none)* | the Actions token has to be able to write |
| `required_linear_history` | on | off | a mirror can't demand a stricter history than its source |
| force pushes | blocked | blocked | unchanged |
| deletions | blocked | blocked | unchanged |
| enforce on admins | on | on | unchanged |

The allowlist had to go rather than be extended: legacy branch protection accepts only installed GitHub Apps there and silently ignored the Actions bot (the POST returned success and added nothing), and a repository-level ruleset refuses it outright — `Actor GitHub Actions integration must be part of the ruleset source or owner organization`.

## State

`main` has already been fast-forwarded to `dev` by hand, so the two are `identical` at `b322013` as of now. This workflow only fires on future pushes to `dev`, so that catch-up wasn't something it would have done.
