### PR TITLE
Tag and release from a version bump that reaches main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - 'v*.*.*'   # triggers on tags like v1.0.0, v1.1.0
+  # Called by Tag release once the version on main gains a tag. That workflow
+  # pushes the tag with GITHUB_TOKEN, which deliberately does NOT trigger the
+  # `push: tags` path above — GitHub suppresses workflow triggers from its own
+  # token — so this entry point is how the release actually gets built, and the
+  # suppression stops the two paths from racing to create the same release.
+  workflow_call:
+    inputs:
+      tag:
+        description: The vX.Y.Z tag to build the release for.
+        required: true
+        type: string
 
 jobs:
   release:
@@ -13,6 +24,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Under workflow_call the caller's ref is checked out by default,
+          # which is main — close enough today, but it would silently build
+          # whatever main became if it moved between the tag and this job.
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Fetch Flutter SDK
         run: |
@@ -55,7 +71,9 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+        # GITHUB_REF_NAME is the tag when triggered by a tag push, but the
+        # caller's branch under workflow_call, so the input wins when present.
+        run: echo "version=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,96 @@
+name: Tag release
+
+# Turns a version bump that has reached main into a tag and a GitHub Release.
+#
+# The version in pubspec.yaml is the trigger, deliberately: bumping it is
+# already a considered decision made in a reviewed pull request, so this
+# workflow carries that decision out rather than making a new one. Nothing here
+# decides *whether* to release.
+#
+# Ordering: a merge to dev runs Test, Test green runs Sync main, Sync main
+# fast-forwards main, and this runs after that. Reading the version from main
+# (not dev) means a release can only ever describe a commit that is on the
+# release branch.
+on:
+  workflow_run:
+    workflows: [Sync main]
+    types: [completed]
+  # Recovery hatch: re-run against whatever main holds now.
+  workflow_dispatch:
+
+# Two syncs landing close together would otherwise both read main, both see no
+# tag, and both try to create it — the loser failing on a ref that already
+# exists, which reads like a real error.
+concurrency:
+  group: tag-release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    # Only tag a main that Sync main actually moved. workflow_dispatch carries
+    # no conclusion, so let it through explicitly.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.decide.outputs.tag }}
+      should_release: ${{ steps.decide.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          # Tags are needed to tell "already released" from "not yet".
+          fetch-depth: 0
+
+      - name: Decide whether main needs a tag
+        id: decide
+        run: |
+          set -euo pipefail
+          VERSION=$(sed -n 's/^version: *//p' pubspec.yaml | tr -d '[:space:]')
+          if [ -z "$VERSION" ]; then
+            echo "::error::pubspec.yaml has no version field."
+            exit 1
+          fi
+          TAG="v$VERSION"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          # The normal case by a wide margin: most merges to main are not
+          # releases, so this exits quietly rather than treating it as notable.
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "$TAG already exists — nothing to release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          echo "main is at $VERSION with no $TAG — tagging $(git rev-parse HEAD)."
+
+      - name: Push the tag
+        if: steps.decide.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          # Annotated, so the tag records when and why it was created rather
+          # than being an anonymous pointer.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.decide.outputs.tag }}" \
+            -m "flutter-tvos ${{ steps.decide.outputs.tag }}" \
+            -m "Tagged automatically from main at version ${{ steps.decide.outputs.tag }}."
+          git push origin "${{ steps.decide.outputs.tag }}"
+
+  # Called rather than left to the tag push, which cannot trigger it: GitHub
+  # suppresses workflow triggers from pushes made with GITHUB_TOKEN. Relying on
+  # the trigger would leave the tag on the repository with no release built and
+  # nothing reporting a failure — so the release is invoked explicitly, and the
+  # suppression conveniently stops both entry points from firing at once.
+  release:
+    needs: tag
+    if: needs.tag.outputs.should_release == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.tag.outputs.tag }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -54,7 +54,28 @@ jobs:
             echo "::error::pubspec.yaml has no version field."
             exit 1
           fi
-          TAG="v$VERSION"
+
+          # Tags name both halves of the pair: v<flutter>-tvos.<cli>, e.g.
+          # v3.47.1-tvos.1.7.0. The CLI version alone would drop the one thing
+          # the scheme exists to record — which Flutter release these artifacts
+          # and this CLI go together with — and the two move independently.
+          #
+          # Only the commit is pinned in the repository, so the release name is
+          # resolved back from it rather than duplicated into a second file that
+          # could disagree with the pin.
+          FLUTTER_COMMIT=$(tr -d '[:space:]' < bin/internal/flutter.version)
+          FLUTTER_VERSION=$(git ls-remote --tags https://github.com/flutter/flutter.git \
+            | awk -v sha="$FLUTTER_COMMIT" '$1 == sha { sub(/\^\{\}$/, "", $2); sub(/^refs\/tags\//, "", $2); print $2 }' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$FLUTTER_VERSION" ]; then
+            echo "::error::no flutter/flutter release tag points at $FLUTTER_COMMIT."
+            echo "The pin is either a pre-release or not on a tagged commit, so the"
+            echo "release cannot be named. Tag by hand, or pin a tagged release."
+            exit 1
+          fi
+          echo "Flutter pin $FLUTTER_COMMIT resolves to $FLUTTER_VERSION."
+
+          TAG="v$FLUTTER_VERSION-tvos.$VERSION"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
           # The normal case by a wide margin: most merges to main are not
@@ -78,7 +99,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${{ steps.decide.outputs.tag }}" \
             -m "flutter-tvos ${{ steps.decide.outputs.tag }}" \
-            -m "Tagged automatically from main at version ${{ steps.decide.outputs.tag }}."
+            -m "Tagged automatically from main."
           git push origin "${{ steps.decide.outputs.tag }}"
 
   # Called rather than left to the tag push, which cannot trigger it: GitHub


### PR DESCRIPTION
The last manual step in the release chain was pushing the tag after `main` synced. Forgetting it is silent: `main` carries a bumped version, no release exists, and nothing reports anything.

`Tag release` runs after `Sync main`, reads the version from `main`'s pubspec, and does nothing unless there is no matching tag — which is the case for most merges, so the quiet path is the common one. The version is the trigger deliberately: bumping it is already a considered decision made in a reviewed pull request, and this carries that decision out rather than making a new one. Nothing here decides *whether* to release.

## The part that would have made it silently useless

GitHub suppresses workflow triggers for pushes made with `GITHUB_TOKEN`, so a tag pushed by a workflow cannot start `Release` the way a hand-pushed one does. Left implicit, the tag would land on the repository with no release built and no failure reported — the exact gap this exists to close, reintroduced one level up.

So `Release` gained a `workflow_call` entry point and is invoked explicitly. The suppression then works in our favour: the two entry points cannot race to create the same release. A hand-pushed tag still behaves exactly as before.

`Release` also takes the tag as an input now. Under `workflow_call` the caller's ref is checked out by default — `main` — which would build whatever `main` had become by then rather than the tagged commit.

No new secrets. A PAT would also have worked, at the cost of an expiry that fails this the same silent way.

## Tag naming

Tags here are `v<flutter>-tvos.<cli>` (`v3.47.1-tvos.1.7.0`), as every release since 3.41.4 has been. The CLI version alone drops the one thing the scheme records — which Flutter release the CLI and artifacts pair with — and the two move independently, so the pairing is not recoverable afterwards.

Only the Flutter *commit* is pinned in the repo, so the version is resolved back from it against `flutter/flutter`'s tags rather than duplicated into a second file that could drift from the pin. A pin with no release tag pointing at it is a hard failure: it means the pair cannot be named, and guessing would produce a tag that misdescribes what shipped.

Verified against the current tree: pin `6655482e` resolves to `3.47.1`, pubspec reads `1.7.0`, and the composed tag is `v3.47.1-tvos.1.7.0` — the tag 1.7.0 actually shipped under.

## What happens when this lands

It runs for the first time on its own merge, finds `main` at 1.7.0 with `v3.47.1-tvos.1.7.0` already present, and exits without doing anything — which is the behaviour to expect from most merges, and a harmless first exercise.
