### PR TITLE
Let xcodebuild authenticate with an App Store Connect API key (1.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to flutter-tvos will be documented here.
 
-## [Unreleased]
+## [1.10.0] - 2026-09-03
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to flutter-tvos will be documented here.
 
 ## [1.10.0] - 2026-09-03
 
+### Fixed
+
+- **The engine is now signed with your `Apple Distribution` certificate**,
+  instead of `Developer ID Application`. 1.9.0 stopped publishing origin-signed
+  artifacts and signs the engine locally instead, but it would only sign with a
+  Developer ID — a certificate only a team's Account Holder can create, subject
+  to a per-team cap, and one a tvOS developer has no other reason to hold. A
+  developer without one got a warning on an otherwise successful build and an
+  unsigned engine in the bundle, then ITMS-91065 at submission. That is a
+  regression against 1.4.0-1.8.0, where the published artifact carried a
+  signature and nothing was required of the developer.
+
+  `Apple Distribution` is the certificate every developer who can upload to
+  TestFlight already has, so signing now asks nothing extra of anyone. Verified
+  end to end against Apple: a tvOS build whose engine was signed
+  `Apple Distribution` before embedding processed to `VALID` and cleared
+  external testing, where the same build with an unsigned engine is rejected.
+
+  `Developer ID Application` also satisfies the check and is what flutter.dev
+  signs its own engine with, but it is no longer used: nobody shipping a tvOS
+  app needs one, so accepting it would only add a branch that almost never
+  fires. A development certificate is refused, as it is not known to satisfy
+  the check.
+
+  No action is needed on an existing project — signing happens in the artifact
+  cache on every device build, so upgrading the CLI is enough.
+
 ### Added
 
 - **`xcodebuild` can authenticate with an App Store Connect API key.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,25 @@ All notable changes to flutter-tvos will be documented here.
   export APP_STORE_CONNECT_ISSUER_ID=<issuer-uuid>
   ```
 
-  Absent or incomplete, nothing is added and a machine with a working Xcode
-  account behaves exactly as before. Set but pointing at a file that does not
-  exist earns a warning rather than a silent fallback — staying quiet there is
-  indistinguishable from never having configured it, and the build goes on to
-  fail with the capability message above, minutes later and nowhere near the
-  cause. Only the key id is ever logged; the key's contents are read by
-  xcodebuild, never by the CLI.
+  Values are trimmed, and a leading `~` is expanded against `HOME` — an
+  interactive shell expands one before the CLI ever sees it, but a CI `env:`
+  block, a quoted assignment, a `.env` file and an Xcode scheme variable all
+  deliver it literally.
+
+  Absent entirely, nothing is added and a machine with a working Xcode account
+  behaves exactly as before, silently. Anything *between* that and a working
+  setup is reported: a partly-set trio, a value that is empty rather than
+  absent (which is how an undefined CI secret arrives), or a key path that
+  does not exist. Staying quiet in those cases is indistinguishable from never
+  having configured it, and the build goes on to fail with the capability
+  message above, minutes later and nowhere near the cause. A successful
+  handover names the key id at default verbosity, so "working" and
+  "half-configured" can be told apart from the log.
+
+  The `.p8` contents never pass through the CLI — only the path is read, and
+  xcodebuild opens the file itself. The path, key id and issuer id are not
+  secret and do appear in output, both on that success line and in
+  xcodebuild's own echoed command line, which is dumped on a failed build.
 
   How it was established: an Apple TV device build of an app carrying
   `com.apple.developer.game-center` failed with the message above. The App ID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to flutter-tvos will be documented here.
 
+## [Unreleased]
+
+### Added
+
+- **`xcodebuild` can authenticate with an App Store Connect API key.**
+  `-allowProvisioningUpdates` lets Xcode create or refresh a provisioning
+  profile, but on its own it can only do so through a signed-in Xcode account.
+  On a machine without a usable one — CI, or a developer who only has an API
+  key — xcodebuild cannot fetch the profile and quietly settles for a cached
+  wildcard instead.
+
+  Any app with an entitlement then fails, and fails misleadingly:
+
+  ```
+  error: Provisioning profile "tvOS Team Provisioning Profile: *"
+  doesn't include the Game Center capability.
+  ```
+
+  That names the capability the *wildcard* lacks, not the credential that is
+  actually missing, so the obvious next step is to go auditing the App ID's
+  capabilities in the developer portal — where everything is already correct.
+
+  Set all three and the key is forwarded:
+
+  ```sh
+  export APP_STORE_CONNECT_KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_XXXX.p8
+  export APP_STORE_CONNECT_KEY_ID=XXXXXXXXXX
+  export APP_STORE_CONNECT_ISSUER_ID=<issuer-uuid>
+  ```
+
+  Absent or incomplete, nothing is added and a machine with a working Xcode
+  account behaves exactly as before. Set but pointing at a file that does not
+  exist earns a warning rather than a silent fallback — staying quiet there is
+  indistinguishable from never having configured it, and the build goes on to
+  fail with the capability message above, minutes later and nowhere near the
+  cause. Only the key id is ever logged; the key's contents are read by
+  xcodebuild, never by the CLI.
+
+  How it was established: an Apple TV device build of an app carrying
+  `com.apple.developer.game-center` failed with the message above. The App ID
+  was `UNIVERSAL` and already had `GAME_CENTER` enabled; querying the App Store
+  Connect API showed the real gap was that no `TVOS_APP_DEVELOPMENT` profile
+  existed for that bundle at all — iOS, App Store, watch and Mac profiles were
+  all present. With the key forwarded, xcodebuild created the missing profile
+  and the same build signed, installed and launched on the device unchanged.
+
+### Changed
+
+- `CONTRIBUTING.md` now warns that the compiled CLI snapshot is only
+  invalidated by a change in git revision, so an edit under `lib/` does
+  nothing until `bin/cache/flutter-tvos.snapshot` is removed. Detecting this
+  in the tool was measured and rejected: it costs ~28ms of `git status` on
+  every invocation, paid by every user to help only the few editing the CLI.
+
 ## [1.9.0] - 2026-08-29
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,17 +44,19 @@ The Flutter SDK is bootstrapped automatically into `flutter/` when you first run
 flutter/bin/dart test test/
 ```
 
-There are 74 unit tests in `test/general/`. They use Flutter's own test infrastructure (`FakeProcessManager`, `testWithoutContext`, `testUsingContext`) and do not require a connected device or simulator.
+There are roughly 450 unit tests across the 40 files in `test/general/`. They use Flutter's own test infrastructure (`FakeProcessManager`, `testWithoutContext`, `testUsingContext`) and do not require a connected device or simulator.
+
+**The suite is not currently green.** `dev` reports 58 failures at HEAD, so take a baseline before you start and compare against it rather than against zero — otherwise pre-existing failures read as yours.
 
 ### Editing the CLI itself
 
-`flutter-tvos` runs a snapshot compiled to `bin/cache/flutter-tvos.snapshot`, and `bin/internal/shared.sh` only recompiles it when the git revision changes. **An edit under `lib/` or `bin/` therefore does nothing until you remove it:**
+`flutter-tvos` runs a snapshot compiled to `bin/cache/flutter-tvos.snapshot`, and `bin/internal/shared.sh` only recompiles it when `git rev-parse HEAD` changes. **An *uncommitted* edit under `lib/` or `bin/` therefore does nothing until you remove it:**
 
 ```bash
 rm bin/cache/flutter-tvos.snapshot
 ```
 
-Worth knowing before you lose an afternoon to it. The stale snapshot does not announce itself — your change appears to have run and had no effect, so the same build fails the same way, byte for byte, and it reads as a wrong fix rather than one that never executed.
+Committing the edit moves `HEAD` and rebuilds the snapshot on its own, so this bites during the edit-and-try loop specifically. Worth knowing before you lose an afternoon to it: the stale snapshot does not announce itself — your change appears to have run and had no effect, so the same build fails the same way, byte for byte, and it reads as a wrong fix rather than one that never executed.
 
 (The revision is only stale-checked this way in a git checkout. A non-git install hashes the contents of `bin/` and `lib/` instead, and needs nothing.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,12 +41,12 @@ Internal-only changes (refactors, CI, test-only changes) don't need a changelog 
 The Flutter SDK is bootstrapped automatically into `flutter/` when you first run any `flutter-tvos` command. Once it is present, run the full test suite from the `flutter-tvos/` directory:
 
 ```bash
-flutter/bin/dart test test/
+TMPDIR="$(cd "${TMPDIR:-/tmp}" && pwd -P)" flutter/bin/dart test test/
 ```
 
-There are roughly 450 unit tests across the 40 files in `test/general/`. They use Flutter's own test infrastructure (`FakeProcessManager`, `testWithoutContext`, `testUsingContext`) and do not require a connected device or simulator.
+There are roughly 450 unit tests across the 40 files in `test/general/`. They use Flutter's own test infrastructure (`FakeProcessManager`, `testWithoutContext`, `testUsingContext`) and do not require a connected device or simulator. **The suite is green** — anything failing is yours.
 
-**The suite is not currently green.** `dev` reports 58 failures at HEAD, so take a baseline before you start and compare against it rather than against zero — otherwise pre-existing failures read as yours.
+**On macOS, keep the `TMPDIR` prefix.** Without it roughly 58 tests fail, and they fail in a way that looks like real breakage rather than an environment problem. Flutter's test harness installs an FS guard that resolves symlinks when computing the allowed temp root but not on the path it checks; `$TMPDIR` is `/var/folders/…` and `/var` is a symlink to `/private/var`, so the two never compare equal. CI passes the resolved form for this reason. Do not reach for `FLUTTER_TEST_DISABLE_FS_GUARD` instead — see `test/README.md`.
 
 ### Editing the CLI itself
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,18 @@ flutter/bin/dart test test/
 
 There are 74 unit tests in `test/general/`. They use Flutter's own test infrastructure (`FakeProcessManager`, `testWithoutContext`, `testUsingContext`) and do not require a connected device or simulator.
 
+### Editing the CLI itself
+
+`flutter-tvos` runs a snapshot compiled to `bin/cache/flutter-tvos.snapshot`, and `bin/internal/shared.sh` only recompiles it when the git revision changes. **An edit under `lib/` or `bin/` therefore does nothing until you remove it:**
+
+```bash
+rm bin/cache/flutter-tvos.snapshot
+```
+
+Worth knowing before you lose an afternoon to it. The stale snapshot does not announce itself — your change appears to have run and had no effect, so the same build fails the same way, byte for byte, and it reads as a wrong fix rather than one that never executed.
+
+(The revision is only stale-checked this way in a git checkout. A non-git install hashes the contents of `bin/` and `lib/` instead, and needs nothing.)
+
 ## Static Analysis
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A Flutter toolchain for building and running Flutter apps on **Apple TV (tvOS)**
 - flutter-tvos: `1.10.0`
 - Flutter SDK: `3.47.2` (`d3b14c876900e553bc736ca19295fc09e3853e8e`)
 - tvOS engine artifacts: published unsigned — `flutter-tvos` signs the engine on
-  your machine with your own `Developer ID Application` certificate on every
-  device build, which is what Apple's ITMS-91065 check requires. See
-  "Code signing" below.
+  your machine with your own `Apple Distribution` certificate on every device
+  build, which is what Apple's ITMS-91065 check requires. See "Code signing"
+  below.
 
 The engine artifact tag is the commit that produced those artifacts, rather than
 a Flutter version. A version-shaped tag went stale as soon as one patch set was
@@ -159,28 +159,32 @@ Then inside `io_impl.dart`, branch on `Platform.isTvOS` vs `Platform.isIOS`.
 ## Code signing
 
 Apple treats Flutter as a "commonly used third-party SDK", and rejects any
-submission whose engine did not already carry a `Developer ID Application`
-signature when the build embedded it (**ITMS-91065**, *"Missing signature"*).
-Signing the copy inside the app is not enough, and neither is the Distribution
-signature `xcodebuild -exportArchive` applies. The engine artifacts published here are
-deliberately unsigned — a public project should not stamp one maintainer's
-Developer ID onto every download — so **`flutter-tvos` signs the engine on your
-machine instead**, with your own certificate, on every device build.
+submission whose engine did not already carry a signature when the build
+embedded it (**ITMS-91065**, *"Missing signature"*). Signing the copy inside the
+app is not enough, and neither is the signature `xcodebuild -exportArchive`
+applies. The engine artifacts published here are deliberately unsigned — a
+public project should not stamp one maintainer's identity onto every download —
+so **`flutter-tvos` signs the engine on your machine instead**, with your own
+certificate, on every device build.
 
-You need a **`Developer ID Application`** certificate in your login keychain.
-Nothing to configure: the CLI finds it, signs the engine with
-`--timestamp --options runtime` (matching how flutter.dev signs its own), and
-skips the work on later builds. Simulator builds never need it.
+**Usually there is nothing to do.** The CLI signs with your `Apple Distribution`
+certificate — the one you already need in order to upload to TestFlight at all —
+using `--timestamp --options runtime`, and skips the work on later builds.
+Simulator builds never need it.
 
 ```sh
-security find-identity -v -p codesigning | grep "Developer ID Application"
+security find-identity -v -p codesigning | grep "Apple Distribution"
 ```
 
-Nothing listed? Create one at
+`Developer ID Application` also satisfies the check — it is what flutter.dev
+signs its own engine with — but flutter-tvos does not use it: only a team's
+Account Holder can create one, and no tvOS developer needs one otherwise. A
+*development* certificate is deliberately not used either; it is not known to
+satisfy the check.
+
+Nothing listed at all? Create an Apple Distribution certificate in Xcode
+(**Settings → Accounts → Manage Certificates**) or at
 [developer.apple.com → Certificates](https://developer.apple.com/account/resources/certificates).
-Apple allows only a team's **Account Holder** to create Developer ID
-certificates, and caps how many a team may have — if you are an Admin on someone
-else's team, ask the Account Holder for one.
 
 Without a certificate the build still succeeds and warns you; the app runs
 locally and on internal TestFlight, then fails external Beta App Review. That

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Flutter toolchain for building and running Flutter apps on **Apple TV (tvOS)**
 
 ## Current version
 
-- flutter-tvos: `1.9.0`
+- flutter-tvos: `1.10.0`
 - Flutter SDK: `3.47.2` (`d3b14c876900e553bc736ca19295fc09e3853e8e`)
 - tvOS engine artifacts: published unsigned — `flutter-tvos` signs the engine on
   your machine with your own `Developer ID Application` certificate on every

--- a/README.md
+++ b/README.md
@@ -196,6 +196,43 @@ processing to `VALID`, and internal TestFlight **all succeed** with an unsigned
 engine. Only pushing a build to an external TestFlight group exercises this
 check, so that is the only way to confirm a submission is really clean.
 
+### Provisioning on a machine with no Xcode account
+
+A device build passes `-allowProvisioningUpdates` so Xcode can create or refresh
+the provisioning profile. On its own that only works through a signed-in Xcode
+account — on CI, or on a machine that only holds an API key, xcodebuild cannot
+fetch the profile and quietly settles for a cached **wildcard** one. Any app
+with an entitlement then fails with a message naming the capability the
+wildcard lacks rather than the credential that is actually missing:
+
+```
+error: Provisioning profile "tvOS Team Provisioning Profile: *"
+doesn't include the Game Center capability.
+```
+
+Set all three of these and the key is forwarded to xcodebuild instead:
+
+| Variable | Effect |
+|---|---|
+| `APP_STORE_CONNECT_KEY_PATH` | Path to the `.p8` private key. `~` is expanded. |
+| `APP_STORE_CONNECT_KEY_ID` | The key's id, e.g. `ABC1234567`. |
+| `APP_STORE_CONNECT_ISSUER_ID` | The issuer id (a UUID). Note this one has no `KEY_`. |
+
+```sh
+export APP_STORE_CONNECT_KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_ABC1234567.p8
+export APP_STORE_CONNECT_KEY_ID=ABC1234567
+export APP_STORE_CONNECT_ISSUER_ID=00000000-1111-2222-3333-444444444444
+```
+
+xcodebuild requires all three or none, so a partial set is not forwarded — but
+it is reported, as is an empty value (how an undefined CI secret arrives) and a
+key path that does not exist. Set none of them and nothing changes: a machine
+with a working Xcode account behaves exactly as before.
+
+The `.p8` contents never pass through the CLI; only the path is read, and
+xcodebuild opens the file itself. The path, key id and issuer id are not secret
+and do appear in build output.
+
 ## Add tvOS support to an existing plugin
 
 If a plugin already implements iOS or macOS, `flutter-tvos plugin port`

--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -6,7 +6,7 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/logger.dart' show Status;
+import 'package:flutter_tools/src/base/logger.dart' show Logger, Status;
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/depfile.dart';
@@ -414,6 +414,65 @@ class ReleaseTvosApplication extends Target {
 /// 4. Generate xcconfig files
 /// 5. Run pod install if Podfile exists
 /// 6. Invoke xcodebuild targeting appletvos or appletvsimulator SDK
+/// App Store Connect API credentials for `xcodebuild`, read from [environment].
+///
+/// `-allowProvisioningUpdates` lets Xcode create or refresh a provisioning
+/// profile, but on its own it can only do so through a signed-in Xcode
+/// account. Where there is no usable account -- CI, or a machine that only
+/// has an API key -- xcodebuild cannot fetch the profile and quietly settles
+/// for a cached wildcard one instead. Any app with an entitlement then fails
+/// with a message naming the *capability* the wildcard lacks ("doesn't
+/// include the Game Center capability") rather than the credential that is
+/// actually missing, which sends you looking in the wrong place.
+///
+/// xcodebuild accepts an API key as the alternative, so forward one when all
+/// three variables are present and the key file exists:
+///
+///   APP_STORE_CONNECT_KEY_PATH   the .p8 private key
+///   APP_STORE_CONNECT_KEY_ID     its key id
+///   APP_STORE_CONNECT_ISSUER_ID  the issuer id
+///
+/// Returns an empty list otherwise, so a machine with a working Xcode account
+/// behaves exactly as before. Only the key *id* is ever logged; the key's
+/// contents are read by xcodebuild, never by this process.
+@visibleForTesting
+List<String> resolveAuthenticationArgs(
+  Map<String, String> environment,
+  FileSystem fileSystem,
+  Logger logger,
+) {
+  final String? keyPath = environment['APP_STORE_CONNECT_KEY_PATH'];
+  final String? keyId = environment['APP_STORE_CONNECT_KEY_ID'];
+  final String? issuerId = environment['APP_STORE_CONNECT_ISSUER_ID'];
+  if (keyPath == null ||
+      keyId == null ||
+      issuerId == null ||
+      keyPath.isEmpty ||
+      keyId.isEmpty ||
+      issuerId.isEmpty) {
+    return const <String>[];
+  }
+  if (!fileSystem.file(keyPath).existsSync()) {
+    // Set but wrong is worth saying out loud: silently falling back looks
+    // identical to never having configured it, and the build then fails much
+    // later with the misleading capability error described above.
+    logger.printWarning(
+      'APP_STORE_CONNECT_KEY_PATH is set but $keyPath does not exist; '
+      'falling back to the Xcode account for provisioning.',
+    );
+    return const <String>[];
+  }
+  logger.printTrace('Authenticating xcodebuild with App Store Connect API key $keyId.');
+  return <String>[
+    '-authenticationKeyPath',
+    fileSystem.path.absolute(keyPath),
+    '-authenticationKeyID',
+    keyId,
+    '-authenticationKeyIssuerID',
+    issuerId,
+  ];
+}
+
 class NativeTvosBundle extends Target {
   NativeTvosBundle(this.buildInfo, this.targetFile);
 
@@ -552,6 +611,13 @@ class NativeTvosBundle extends Target {
         // -allowProvisioningUpdates". Not used for the simulator, which
         // is not code-signed.
         if (!buildInfo.simulator) '-allowProvisioningUpdates',
+        // ...and give it something to authenticate *with*.
+        if (!buildInfo.simulator)
+          ...resolveAuthenticationArgs(
+            globals.platform.environment,
+            globals.fs,
+            globals.logger,
+          ),
         'build',
       ], workingDirectory: tvosProjectDir.path);
     } finally {

--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -405,15 +405,6 @@ class ReleaseTvosApplication extends Target {
   }
 }
 
-/// Orchestrates the native tvOS build via xcodebuild.
-///
-/// Build steps:
-/// 1. Copy Flutter.framework from engine artifacts into tvos/Flutter/
-/// 2. Copy flutter_assets into tvos/Flutter/flutter_assets/
-/// 3. Generate GeneratedPluginRegistrant.h/.m
-/// 4. Generate xcconfig files
-/// 5. Run pod install if Podfile exists
-/// 6. Invoke xcodebuild targeting appletvos or appletvsimulator SDK
 /// App Store Connect API credentials for `xcodebuild`, read from [environment].
 ///
 /// `-allowProvisioningUpdates` lets Xcode create or refresh a provisioning
@@ -433,46 +424,122 @@ class ReleaseTvosApplication extends Target {
 ///   APP_STORE_CONNECT_ISSUER_ID  the issuer id
 ///
 /// Returns an empty list otherwise, so a machine with a working Xcode account
-/// behaves exactly as before. Only the key *id* is ever logged; the key's
-/// contents are read by xcodebuild, never by this process.
+/// behaves exactly as before. The distinction that matters is between having
+/// configured *nothing* and having configured *something broken*: the second
+/// is always reported, because it is otherwise indistinguishable from the
+/// first and the build goes on to fail minutes later with the misleading
+/// capability error above.
+///
+/// The `.p8` contents never pass through this process -- only the path is
+/// read, and xcodebuild opens the file itself. The path, key id and issuer id
+/// are not secret and do appear in output: on the success line here, and in
+/// xcodebuild's own echoed command line, which the caller dumps on failure.
 @visibleForTesting
 List<String> resolveAuthenticationArgs(
   Map<String, String> environment,
   FileSystem fileSystem,
   Logger logger,
 ) {
-  final String? keyPath = environment['APP_STORE_CONNECT_KEY_PATH'];
-  final String? keyId = environment['APP_STORE_CONNECT_KEY_ID'];
-  final String? issuerId = environment['APP_STORE_CONNECT_ISSUER_ID'];
-  if (keyPath == null ||
-      keyId == null ||
-      issuerId == null ||
-      keyPath.isEmpty ||
-      keyId.isEmpty ||
-      issuerId.isEmpty) {
+  const pathVar = 'APP_STORE_CONNECT_KEY_PATH';
+  const idVar = 'APP_STORE_CONNECT_KEY_ID';
+  const issuerVar = 'APP_STORE_CONNECT_ISSUER_ID';
+
+  // Trim: a value sourced from `$(cat keyid)`, a secret store or a here-doc
+  // commonly carries a trailing newline, and forwarding one produces a
+  // baffling failure -- in a path, the invisible `\n` renders a warning whose
+  // path looks perfectly correct.
+  final String path = (environment[pathVar] ?? '').trim();
+  final String id = (environment[idVar] ?? '').trim();
+  final String issuer = (environment[issuerVar] ?? '').trim();
+
+  if (path.isEmpty || id.isEmpty || issuer.isEmpty) {
+    // Distinguish "never configured" from "configured, but not usably". A
+    // half-set trio must not produce half a flag set -- xcodebuild rejects
+    // the key arguments unless all three are present -- but going quiet about
+    // it is the very failure this function exists to prevent. Note the test
+    // is *presence in the environment*, not a non-empty value: an undefined
+    // GitHub Actions secret interpolates to the empty string, so all three
+    // variables are set and the operator has demonstrably configured this.
+    final missing = <String>[
+      if (path.isEmpty) pathVar,
+      if (id.isEmpty) idVar,
+      if (issuer.isEmpty) issuerVar,
+    ];
+    final bool configuredSomething = <String>[pathVar, idVar, issuerVar]
+        .any(environment.containsKey);
+    if (configuredSomething) {
+      logger.printWarning(
+        'App Store Connect API key authentication is partly configured: '
+        '${missing.join(', ')} ${missing.length == 1 ? 'is' : 'are'} unset or '
+        'empty. xcodebuild needs all three, so none are being forwarded and '
+        'provisioning falls back to the Xcode account. (An undefined CI secret '
+        'arrives as an empty string, and the third variable is '
+        '$issuerVar -- not APP_STORE_CONNECT_KEY_ISSUER_ID.)',
+      );
+    }
     return const <String>[];
   }
-  if (!fileSystem.file(keyPath).existsSync()) {
-    // Set but wrong is worth saying out loud: silently falling back looks
-    // identical to never having configured it, and the build then fails much
-    // later with the misleading capability error described above.
+
+  // A literal `~` only means the home directory to a shell. A CI `env:` block,
+  // a quoted assignment, a `.env` file and an Xcode scheme variable all
+  // deliver it verbatim, where it would otherwise be resolved against the cwd
+  // into `/~/...` and never exist.
+  final String expanded = _expandTilde(path, environment);
+  // `existsSync` resolves relative paths against *this* process's cwd, while
+  // xcodebuild below runs with `workingDirectory: tvosProjectDir.path`. Make
+  // it absolute here or a relative key path passes the check and is then
+  // handed to xcodebuild one directory deeper.
+  final String resolved = fileSystem.path.absolute(expanded);
+
+  if (!fileSystem.file(resolved).existsSync()) {
     logger.printWarning(
-      'APP_STORE_CONNECT_KEY_PATH is set but $keyPath does not exist; '
-      'falling back to the Xcode account for provisioning.',
+      '$pathVar is set but $resolved does not exist; falling back to the '
+      'Xcode account for provisioning.'
+      '${path.startsWith('~') && expanded == path ? ' (The leading `~` was '
+          'passed through literally and no HOME is set to expand it against; '
+          'use an absolute path.)' : ''}',
     );
     return const <String>[];
   }
-  logger.printTrace('Authenticating xcodebuild with App Store Connect API key $keyId.');
+
+  // printStatus, not printTrace: StdoutLogger.printTrace is a no-op, so a
+  // trace here would leave "working", "half-configured" and "never
+  // configured" indistinguishable at default verbosity -- and this runs once
+  // per device build, not per file.
+  logger.printStatus('Authenticating xcodebuild with App Store Connect API key $id.');
   return <String>[
     '-authenticationKeyPath',
-    fileSystem.path.absolute(keyPath),
+    resolved,
     '-authenticationKeyID',
-    keyId,
+    id,
     '-authenticationKeyIssuerID',
-    issuerId,
+    issuer,
   ];
 }
 
+/// Resolves a leading `~` or `~/` against `HOME`, leaving every other path
+/// untouched. Returns [path] unchanged when there is no `HOME` to expand
+/// against, so the caller can tell the two cases apart.
+String _expandTilde(String path, Map<String, String> environment) {
+  if (path != '~' && !path.startsWith('~/')) {
+    return path;
+  }
+  final String home = (environment['HOME'] ?? '').trim();
+  if (home.isEmpty) {
+    return path;
+  }
+  return path == '~' ? home : '$home/${path.substring(2)}';
+}
+
+/// Orchestrates the native tvOS build via xcodebuild.
+///
+/// Build steps:
+/// 1. Copy Flutter.framework from engine artifacts into tvos/Flutter/
+/// 2. Copy flutter_assets into tvos/Flutter/flutter_assets/
+/// 3. Generate GeneratedPluginRegistrant.h/.m
+/// 4. Generate xcconfig files
+/// 5. Run pod install if Podfile exists
+/// 6. Invoke xcodebuild targeting appletvos or appletvsimulator SDK
 class NativeTvosBundle extends Target {
   NativeTvosBundle(this.buildInfo, this.targetFile);
 
@@ -585,41 +652,34 @@ class NativeTvosBundle extends Target {
     // Code signing settings for physical device builds
     final List<String> signingArgs = await _resolveSigningArgs(tvosProjectDir, buildInfo.simulator);
 
-    final Status xcodeStatus = globals.logger.startProgress('Running Xcode build...');
-    ProcessResult result;
-    try {
-      result = await globals.processManager.run(<String>[
-        'xcodebuild',
-        if (hasWorkspace) ...<String>['-workspace', 'Runner.xcworkspace'] else ...<String>[
-          '-project',
-          'Runner.xcodeproj',
-        ],
-        '-scheme',
-        'Runner',
-        '-configuration',
-        configuration,
-        '-sdk',
-        buildInfo.sdkName,
-        'SYMROOT=$symroot',
-        'COMPILER_INDEX_STORE_ENABLE=NO',
-        'ARCHS=arm64',
-        ...signingArgs,
-        // Mirror upstream `flutter build ios`: let Xcode create/update
-        // the provisioning profile for automatic signing on a physical
-        // device. Without this, a device build fails with "Automatic
-        // signing is disabled and unable to generate a profile … pass
-        // -allowProvisioningUpdates". Not used for the simulator, which
-        // is not code-signed.
-        if (!buildInfo.simulator) '-allowProvisioningUpdates',
-        // ...and give it something to authenticate *with*.
-        if (!buildInfo.simulator)
-          ...resolveAuthenticationArgs(
+    // Resolved *before* startProgress below, not inside the argument list:
+    // this can warn, and a warning raised under the spinner is emitted at the
+    // top of a multi-minute build — then buried under xcodebuild's full
+    // stdout and stderr if the build fails. Same reasoning as the migration
+    // guards further down, which are deliberately emitted after the build.
+    final List<String> authenticationArgs = buildInfo.simulator
+        ? const <String>[]
+        : resolveAuthenticationArgs(
             globals.platform.environment,
             globals.fs,
             globals.logger,
-          ),
-        'build',
-      ], workingDirectory: tvosProjectDir.path);
+          );
+
+    final Status xcodeStatus = globals.logger.startProgress('Running Xcode build...');
+    ProcessResult result;
+    try {
+      result = await globals.processManager.run(
+        xcodebuildArgs(
+          hasWorkspace: hasWorkspace,
+          configuration: configuration,
+          sdkName: buildInfo.sdkName,
+          symroot: symroot,
+          isSimulator: buildInfo.simulator,
+          signingArgs: signingArgs,
+          authenticationArgs: authenticationArgs,
+        ),
+        workingDirectory: tvosProjectDir.path,
+      );
     } finally {
       xcodeStatus.stop();
     }
@@ -1773,6 +1833,52 @@ class NativeTvosBundle extends Target {
       sdkName.contains('simulator')
           ? '-mtvos-simulator-version-min=$_kTvosMinimumOSVersion'
           : '-mtvos-version-min=$_kTvosMinimumOSVersion';
+
+  /// The full `xcodebuild` argv for the native build.
+  ///
+  /// Extracted from [build] so the wiring is testable: that signing and
+  /// authentication arguments actually reach xcodebuild, and that neither is
+  /// passed on a simulator build. [authenticationArgs] comes from
+  /// [resolveAuthenticationArgs], which the caller resolves ahead of the
+  /// progress spinner so its warnings are not buried.
+  @visibleForTesting
+  static List<String> xcodebuildArgs({
+    required bool hasWorkspace,
+    required String configuration,
+    required String sdkName,
+    required String symroot,
+    required bool isSimulator,
+    required List<String> signingArgs,
+    required List<String> authenticationArgs,
+  }) {
+    return <String>[
+      'xcodebuild',
+      if (hasWorkspace) ...<String>['-workspace', 'Runner.xcworkspace'] else ...<String>[
+        '-project',
+        'Runner.xcodeproj',
+      ],
+      '-scheme',
+      'Runner',
+      '-configuration',
+      configuration,
+      '-sdk',
+      sdkName,
+      'SYMROOT=$symroot',
+      'COMPILER_INDEX_STORE_ENABLE=NO',
+      'ARCHS=arm64',
+      ...signingArgs,
+      // Mirror upstream `flutter build ios`: let Xcode create/update
+      // the provisioning profile for automatic signing on a physical
+      // device. Without this, a device build fails with "Automatic
+      // signing is disabled and unable to generate a profile … pass
+      // -allowProvisioningUpdates". Not used for the simulator, which
+      // is not code-signed.
+      if (!isSimulator) '-allowProvisioningUpdates',
+      // ...and give it something to authenticate *with*.
+      if (!isSimulator) ...authenticationArgs,
+      'build',
+    ];
+  }
 
   /// `xcrun cc` argv that assembles the gen_snapshot output to an object file.
   ///

--- a/lib/tvos_engine_signing.dart
+++ b/lib/tvos_engine_signing.dart
@@ -52,6 +52,9 @@ class TvosEngineSigner {
   /// Set to `1` to skip signing entirely.
   static const String kSkipEnvVar = 'TVOS_ENGINE_SKIP_SIGNING';
 
+  /// The certificate type used to sign the engine. See [resolveIdentity].
+  static const String kIdentityPrefix = 'Apple Distribution:';
+
   /// A codesigning identity in the login keychain.
   ///
   /// [hash] is the SHA-1. Everything downstream signs by hash, never by name:
@@ -96,10 +99,21 @@ class TvosEngineSigner {
   /// The identity to sign the engine with, or `null` when there is none and the
   /// build should proceed unsigned.
   ///
-  /// Prefers `Developer ID Application`, which is what flutter.dev uses on its
-  /// own engine artifacts. Falls back to nothing rather than to a development
-  /// certificate: a wrong-type signature is not obviously better than none, and
-  /// silently picking one would hide the real problem.
+  /// Uses `Apple Distribution`, the certificate every developer who can upload
+  /// to TestFlight already holds, so signing asks nothing extra of anyone.
+  ///
+  /// Verified against Apple: a tvOS build whose engine was signed
+  /// `Apple Distribution` before embedding processed to VALID and cleared
+  /// external testing, where the same build with an unsigned engine is
+  /// rejected with ITMS-91065.
+  ///
+  /// Deliberately the only accepted type. `Developer ID Application` also
+  /// works and is what flutter.dev signs its own engine with, but it is a
+  /// macOS outside-the-App-Store certificate that only a team's Account Holder
+  /// can create, subject to a per-team cap — nobody shipping a tvOS app needs
+  /// one, so accepting it would only add a branch that almost never fires.
+  /// A development certificate is not accepted either: it is not known to
+  /// satisfy the check, and silently using one would hide the real problem.
   ({String hash, String name})? resolveIdentity() {
     final List<({String hash, String name})> identities = _availableIdentities();
 
@@ -137,16 +151,16 @@ class TvosEngineSigner {
       return named.single;
     }
 
-    final List<({String hash, String name})> developerIds = identities
-        .where((({String hash, String name}) id) => id.name.startsWith('Developer ID Application:'))
+    final List<({String hash, String name})> matches = identities
+        .where((({String hash, String name}) id) => id.name.startsWith(kIdentityPrefix))
         .toList();
-    if (developerIds.isEmpty) {
+    if (matches.isEmpty) {
       return null;
     }
     // Revoked certificates are already gone, so duplicates here are the
     // renewed-certificate case: same subject, different hash, either will
     // verify. Signing by hash means picking one is safe.
-    return developerIds.first;
+    return matches.first;
   }
 
   /// Signs the engine bundles under [variantDir] (an `engine_artifacts/<variant>`
@@ -250,11 +264,13 @@ class TvosEngineSigner {
 
     if (identity == null) {
       _logger.printStatus(
-        'Warning: no "Developer ID Application" certificate found, so the Flutter '
+        'Warning: no "Apple Distribution" certificate found, so the Flutter '
         'engine is being embedded unsigned.\n'
         'Local builds and internal TestFlight work, but App Store and external '
         'TestFlight submissions are rejected with ITMS-91065 ("Missing signature").\n'
-        'Create one at https://developer.apple.com/account/resources/certificates, '
+        'This is the certificate you already need to upload to TestFlight at all — '
+        'create it in Xcode (Settings > Accounts > Manage Certificates) or at '
+        'https://developer.apple.com/account/resources/certificates, '
         'or set $kIdentityEnvVar to the identity to use. '
         'Set $kSkipEnvVar=1 to silence this.',
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_tvos
 description: Flutter CLI tool for building and running Flutter apps on Apple TV (tvOS). A custom embedder wrapping Flutter SDK with tvOS-specific build targets, device management, and plugin support.
-version: 1.9.0
+version: 1.10.0
 homepage: https://fluttertv.dev
 repository: https://github.com/fluttertv/flutter-tvos
 publish_to: "none"

--- a/test/general/tvos_code_signing_test.dart
+++ b/test/general/tvos_code_signing_test.dart
@@ -140,11 +140,12 @@ buildSettings = {
       logger = BufferLogger.test();
     });
 
-    Map<String, String> env({String? path, String? id, String? issuer}) {
+    Map<String, String> env({String? path, String? id, String? issuer, String? home}) {
       return <String, String>{
         if (path != null) 'APP_STORE_CONNECT_KEY_PATH': path,
         if (id != null) 'APP_STORE_CONNECT_KEY_ID': id,
         if (issuer != null) 'APP_STORE_CONNECT_ISSUER_ID': issuer,
+        if (home != null) 'HOME': home,
       };
     }
 
@@ -168,14 +169,30 @@ buildSettings = {
       );
     });
 
-    testWithoutContext('is inert when nothing is set', () {
+    testWithoutContext('announces the key id at default verbosity', () {
+      // printTrace is a no-op in StdoutLogger, so tracing this would leave
+      // "working", "half-configured" and "never configured" indistinguishable
+      // from the log at default verbosity.
+      fileSystem.file('/keys/AuthKey_ABC.p8').createSync(recursive: true);
+
+      resolveAuthenticationArgs(
+        env(path: '/keys/AuthKey_ABC.p8', id: 'ABC1234567', issuer: 'issuer-uuid'),
+        fileSystem,
+        logger,
+      );
+
+      expect(logger.statusText, contains('ABC1234567'));
+    });
+
+    testWithoutContext('is inert and silent when nothing is set', () {
       // The common case: a machine with a working Xcode account must behave
-      // exactly as it did before this existed.
+      // exactly as it did before this existed, and must not be nagged.
       expect(
         resolveAuthenticationArgs(<String, String>{}, fileSystem, logger),
         isEmpty,
       );
       expect(logger.warningText, isEmpty);
+      expect(logger.statusText, isEmpty);
     });
 
     testWithoutContext('is inert when the trio is incomplete', () {
@@ -200,14 +217,139 @@ buildSettings = {
       );
     });
 
-    testWithoutContext('treats an empty value as unset', () {
+    testWithoutContext('warns which variable is missing when partly configured', () {
+      // Silence here is the same failure this function exists to prevent:
+      // indistinguishable from never having configured it, and the build dies
+      // minutes later with the misleading capability error.
+      fileSystem.file('/keys/AuthKey_ABC.p8').createSync(recursive: true);
+
       expect(
         resolveAuthenticationArgs(
-          env(path: '', id: 'ABC1234567', issuer: 'issuer-uuid'),
+          env(path: '/keys/AuthKey_ABC.p8', id: 'ABC1234567'),
           fileSystem,
           logger,
         ),
         isEmpty,
+      );
+      expect(logger.warningText, contains('APP_STORE_CONNECT_ISSUER_ID'));
+      expect(logger.warningText, isNot(contains('APP_STORE_CONNECT_KEY_PATH is set')));
+    });
+
+    testWithoutContext('warns when a CI secret interpolates to the empty string', () {
+      // An undefined GitHub Actions secret arrives as "", not as an absent
+      // variable: all three are set, the operator has demonstrably configured
+      // this, and treating it as unconfigured loses the only useful signal.
+      fileSystem.file('/keys/AuthKey_ABC.p8').createSync(recursive: true);
+
+      for (final environment in <Map<String, String>>[
+        env(path: '', id: 'ABC1234567', issuer: 'issuer-uuid'),
+        env(path: '/keys/AuthKey_ABC.p8', id: '', issuer: 'issuer-uuid'),
+        env(path: '/keys/AuthKey_ABC.p8', id: 'ABC1234567', issuer: ''),
+      ]) {
+        logger.clear();
+        expect(resolveAuthenticationArgs(environment, fileSystem, logger), isEmpty);
+        expect(logger.warningText, contains('partly configured'));
+      }
+    });
+
+    testWithoutContext('names the asymmetric issuer variable in the warning', () {
+      // APP_STORE_CONNECT_KEY_PATH, _KEY_ID, then _ISSUER_ID: the `KEY_` is
+      // dropped, so APP_STORE_CONNECT_KEY_ISSUER_ID is the natural guess and
+      // is silently ignored.
+      resolveAuthenticationArgs(
+        <String, String>{'APP_STORE_CONNECT_KEY_ISSUER_ID': 'issuer-uuid'},
+        fileSystem,
+        logger,
+      );
+      expect(logger.warningText, isEmpty);
+
+      resolveAuthenticationArgs(
+        env(path: '/keys/AuthKey_ABC.p8', id: 'ABC1234567'),
+        fileSystem,
+        logger,
+      );
+      expect(logger.warningText, contains('not APP_STORE_CONNECT_KEY_ISSUER_ID'));
+    });
+
+    testWithoutContext('trims values that arrive with a trailing newline', () {
+      // `KEY_ID=$(cat keyid)` and most secret stores append one. In a path the
+      // newline is invisible, so the resulting warning looks nonsensical.
+      fileSystem.file('/keys/AuthKey_ABC.p8').createSync(recursive: true);
+
+      expect(
+        resolveAuthenticationArgs(
+          env(
+            path: '/keys/AuthKey_ABC.p8\n',
+            id: 'ABC1234567\n',
+            issuer: 'issuer-uuid\n',
+          ),
+          fileSystem,
+          logger,
+        ),
+        <String>[
+          '-authenticationKeyPath',
+          '/keys/AuthKey_ABC.p8',
+          '-authenticationKeyID',
+          'ABC1234567',
+          '-authenticationKeyIssuerID',
+          'issuer-uuid',
+        ],
+      );
+    });
+
+    testWithoutContext('expands a leading tilde against HOME', () {
+      // A CI `env:` block, a quoted assignment, a `.env` file and an Xcode
+      // scheme variable all deliver a literal `~`, which would otherwise
+      // resolve to `/~/...` and never exist.
+      fileSystem.file('/Users/dev/.appstoreconnect/AuthKey_ABC.p8').createSync(recursive: true);
+
+      expect(
+        resolveAuthenticationArgs(
+          env(
+            path: '~/.appstoreconnect/AuthKey_ABC.p8',
+            id: 'ABC1234567',
+            issuer: 'issuer-uuid',
+            home: '/Users/dev',
+          ),
+          fileSystem,
+          logger,
+        ),
+        containsAllInOrder(<String>[
+          '-authenticationKeyPath',
+          '/Users/dev/.appstoreconnect/AuthKey_ABC.p8',
+        ]),
+      );
+    });
+
+    testWithoutContext('blames the tilde when there is no HOME to expand it against', () {
+      expect(
+        resolveAuthenticationArgs(
+          env(path: '~/keys/AuthKey_ABC.p8', id: 'ABC1234567', issuer: 'issuer-uuid'),
+          fileSystem,
+          logger,
+        ),
+        isEmpty,
+      );
+      expect(logger.warningText, contains('`~`'));
+    });
+
+    testWithoutContext('makes a relative key path absolute', () {
+      // existsSync resolves against this process's cwd, but xcodebuild runs
+      // with workingDirectory: tvosProjectDir.path -- so a relative path that
+      // passes the check here would be handed over one directory deeper.
+      fileSystem.currentDirectory = fileSystem.directory('/work')..createSync();
+      fileSystem.file('/work/keys/AuthKey_ABC.p8').createSync(recursive: true);
+
+      expect(
+        resolveAuthenticationArgs(
+          env(path: 'keys/AuthKey_ABC.p8', id: 'ABC1234567', issuer: 'issuer-uuid'),
+          fileSystem,
+          logger,
+        ),
+        containsAllInOrder(<String>[
+          '-authenticationKeyPath',
+          '/work/keys/AuthKey_ABC.p8',
+        ]),
       );
     });
 
@@ -227,20 +369,93 @@ buildSettings = {
     });
   });
 
-  group('Code signing - simulator vs device', () {
-    testWithoutContext('simulator builds do not need signing', () {
-      // Simulator builds should skip all signing logic
-      const isSimulator = true;
-      if (isSimulator) {
-        // _resolveSigningArgs returns empty list for simulators
-        expect(const <String>[], isEmpty);
-      }
+  group('Code signing - xcodebuild argument wiring', () {
+    List<String> args({
+      bool isSimulator = false,
+      List<String> signingArgs = const <String>[],
+      List<String> authenticationArgs = const <String>[],
+    }) {
+      return NativeTvosBundle.xcodebuildArgs(
+        hasWorkspace: false,
+        configuration: 'Release',
+        sdkName: isSimulator ? 'appletvsimulator' : 'appletvos',
+        symroot: '/build',
+        isSimulator: isSimulator,
+        signingArgs: signingArgs,
+        authenticationArgs: authenticationArgs,
+      );
+    }
+
+    testWithoutContext('a device build forwards the authentication arguments', () {
+      // Without this, the whole feature can be unhooked from the build and
+      // every test of resolveAuthenticationArgs still passes.
+      expect(
+        args(authenticationArgs: <String>[
+          '-authenticationKeyPath',
+          '/keys/AuthKey_ABC.p8',
+          '-authenticationKeyID',
+          'ABC1234567',
+          '-authenticationKeyIssuerID',
+          'issuer-uuid',
+        ]),
+        containsAllInOrder(<String>[
+          '-allowProvisioningUpdates',
+          '-authenticationKeyPath',
+          '/keys/AuthKey_ABC.p8',
+          '-authenticationKeyID',
+          'ABC1234567',
+          '-authenticationKeyIssuerID',
+          'issuer-uuid',
+        ]),
+      );
     });
 
-    testWithoutContext('device builds need signing', () {
-      const isSimulator = false;
-      expect(isSimulator, isFalse);
-      // Device builds should attempt to resolve signing
+    testWithoutContext('a simulator build carries neither signing nor authentication', () {
+      // The simulator is never code-signed, so -allowProvisioningUpdates has
+      // nothing to update and a key has nothing to authenticate for.
+      final List<String> simulatorArgs = args(
+        isSimulator: true,
+        signingArgs: <String>['DEVELOPMENT_TEAM=XYZ9876543'],
+        authenticationArgs: <String>['-authenticationKeyID', 'ABC1234567'],
+      );
+
+      expect(simulatorArgs, isNot(contains('-allowProvisioningUpdates')));
+      expect(simulatorArgs, isNot(contains('-authenticationKeyID')));
+      expect(simulatorArgs, isNot(contains('ABC1234567')));
+    });
+
+    testWithoutContext('signing arguments reach xcodebuild on a device build', () {
+      expect(
+        args(signingArgs: <String>['DEVELOPMENT_TEAM=XYZ9876543', 'CODE_SIGN_STYLE=Automatic']),
+        containsAllInOrder(<String>['DEVELOPMENT_TEAM=XYZ9876543', 'CODE_SIGN_STYLE=Automatic']),
+      );
+    });
+
+    testWithoutContext('selects the project or the workspace', () {
+      expect(args(), containsAllInOrder(<String>['-project', 'Runner.xcodeproj']));
+      expect(
+        NativeTvosBundle.xcodebuildArgs(
+          hasWorkspace: true,
+          configuration: 'Release',
+          sdkName: 'appletvos',
+          symroot: '/build',
+          isSimulator: false,
+          signingArgs: const <String>[],
+          authenticationArgs: const <String>[],
+        ),
+        containsAllInOrder(<String>['-workspace', 'Runner.xcworkspace']),
+      );
+    });
+
+    testWithoutContext('ends with the build action', () {
+      expect(args().first, 'xcodebuild');
+      expect(args().last, 'build');
     });
   });
+
+  // The former 'Code signing - simulator vs device' group lived here. Both of
+  // its cases asserted against local constants -- `expect(const <String>[],
+  // isEmpty)` and `expect(isSimulator, isFalse)` -- so neither could fail, and
+  // neither reached production code. The 'xcodebuild argument wiring' group
+  // above makes the same two claims against NativeTvosBundle.xcodebuildArgs.
 }

--- a/test/general/tvos_code_signing_test.dart
+++ b/test/general/tvos_code_signing_test.dart
@@ -4,6 +4,8 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tvos/build_targets/application.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -128,6 +130,100 @@ buildSettings = {
       final Match? match = identityRegex.firstMatch(securityOutput);
 
       expect(match, isNull);
+    });
+  });
+
+  group('Code signing - App Store Connect API key', () {
+    late BufferLogger logger;
+
+    setUp(() {
+      logger = BufferLogger.test();
+    });
+
+    Map<String, String> env({String? path, String? id, String? issuer}) {
+      return <String, String>{
+        if (path != null) 'APP_STORE_CONNECT_KEY_PATH': path,
+        if (id != null) 'APP_STORE_CONNECT_KEY_ID': id,
+        if (issuer != null) 'APP_STORE_CONNECT_ISSUER_ID': issuer,
+      };
+    }
+
+    testWithoutContext('forwards the key when all three are set', () {
+      fileSystem.file('/keys/AuthKey_ABC.p8').createSync(recursive: true);
+
+      expect(
+        resolveAuthenticationArgs(
+          env(path: '/keys/AuthKey_ABC.p8', id: 'ABC1234567', issuer: 'issuer-uuid'),
+          fileSystem,
+          logger,
+        ),
+        <String>[
+          '-authenticationKeyPath',
+          '/keys/AuthKey_ABC.p8',
+          '-authenticationKeyID',
+          'ABC1234567',
+          '-authenticationKeyIssuerID',
+          'issuer-uuid',
+        ],
+      );
+    });
+
+    testWithoutContext('is inert when nothing is set', () {
+      // The common case: a machine with a working Xcode account must behave
+      // exactly as it did before this existed.
+      expect(
+        resolveAuthenticationArgs(<String, String>{}, fileSystem, logger),
+        isEmpty,
+      );
+      expect(logger.warningText, isEmpty);
+    });
+
+    testWithoutContext('is inert when the trio is incomplete', () {
+      fileSystem.file('/keys/AuthKey_ABC.p8').createSync(recursive: true);
+      // A half-configured environment must not produce half a flag set --
+      // xcodebuild rejects the key arguments unless all three are present.
+      expect(
+        resolveAuthenticationArgs(
+          env(path: '/keys/AuthKey_ABC.p8', id: 'ABC1234567'),
+          fileSystem,
+          logger,
+        ),
+        isEmpty,
+      );
+      expect(
+        resolveAuthenticationArgs(
+          env(path: '/keys/AuthKey_ABC.p8', issuer: 'issuer-uuid'),
+          fileSystem,
+          logger,
+        ),
+        isEmpty,
+      );
+    });
+
+    testWithoutContext('treats an empty value as unset', () {
+      expect(
+        resolveAuthenticationArgs(
+          env(path: '', id: 'ABC1234567', issuer: 'issuer-uuid'),
+          fileSystem,
+          logger,
+        ),
+        isEmpty,
+      );
+    });
+
+    testWithoutContext('warns, and falls back, when the key file is missing', () {
+      // Configured but wrong is the case worth a warning: staying silent looks
+      // identical to never having configured it, and the build then fails much
+      // later complaining about a capability rather than a credential.
+      expect(
+        resolveAuthenticationArgs(
+          env(path: '/keys/absent.p8', id: 'ABC1234567', issuer: 'issuer-uuid'),
+          fileSystem,
+          logger,
+        ),
+        isEmpty,
+      );
+      expect(logger.warningText, contains('/keys/absent.p8'));
     });
   });
 

--- a/test/general/tvos_engine_signing_test.dart
+++ b/test/general/tvos_engine_signing_test.dart
@@ -22,22 +22,30 @@ const String _identities = '''
      4 valid identities found
 ''';
 
+/// The ordinary tvOS developer: an Apple Distribution certificate (required to
+/// upload at all) and no Developer ID, which only an Account Holder can create.
+const String _distributionOnly = '''
+  1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "Apple Development: Someone (ABCDE12345)"
+  2) CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC "Apple Distribution: Someone (TEAM123456)"
+     2 valid identities found
+''';
+
 const String _noDeveloperId = '''
   1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "Apple Development: Someone (ABCDE12345)"
      1 valid identity found
 ''';
 
 /// A revoked certificate. `find-identity` annotates it but still counts it in
-/// the "valid identities found" total, and it is listed *before* the good
-/// Developer ID so that taking the first match would pick the wrong one.
+/// the "valid identities found" total, and it is listed *before* the good one
+/// so that taking the first match would pick the wrong certificate.
 const String _revokedFirst = '''
-  1) EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE "Developer ID Application: Someone (TEAM123456)" (CSSMERR_TP_CERT_REVOKED)
-  2) DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD "Developer ID Application: Someone (TEAM123456)"
+  1) EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE "Apple Distribution: Someone (TEAM123456)" (CSSMERR_TP_CERT_REVOKED)
+  2) CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC "Apple Distribution: Someone (TEAM123456)"
      2 valid identities found
 ''';
 
 const String _revokedOnly = '''
-  1) EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE "Developer ID Application: Someone (TEAM123456)" (CSSMERR_TP_CERT_REVOKED)
+  1) EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE "Apple Distribution: Someone (TEAM123456)" (CSSMERR_TP_CERT_REVOKED)
      1 valid identity found
 ''';
 
@@ -86,13 +94,31 @@ void main() {
   });
 
   group('identity resolution', () {
-    testWithoutContext('prefers Developer ID Application', () {
+    testWithoutContext('uses the Apple Distribution certificate', () {
+      // The regression that broke 1.9.0 for customers: artifacts ship unsigned
+      // and the CLI signs locally, but it only accepted a certificate most
+      // tvOS developers cannot obtain, so their engine shipped unsigned and
+      // Apple rejected it with ITMS-91065.
+      final pm = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: _findIdentity, stdout: _distributionOnly),
+      ]);
+      final ({String hash, String name})? identity =
+          _signer(fs: fileSystem, pm: pm, logger: logger).resolveIdentity();
+      expect(identity?.name, 'Apple Distribution: Someone (TEAM123456)');
+      expect(identity?.hash, 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC');
+    });
+
+    testWithoutContext('picks Apple Distribution even when a Developer ID is present', () {
+      // Developer ID also satisfies the check, but it is not accepted: it is a
+      // certificate almost no tvOS developer holds, so supporting it would add
+      // a branch that practically never fires.
       final pm = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: _findIdentity, stdout: _identities),
       ]);
-      final ({String hash, String name})? identity = _signer(fs: fileSystem, pm: pm, logger: logger).resolveIdentity();
-      expect(identity?.name, 'Developer ID Application: Someone (TEAM123456)');
-      expect(identity?.hash, 'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD');
+      expect(
+        _signer(fs: fileSystem, pm: pm, logger: logger).resolveIdentity()?.name,
+        'Apple Distribution: Someone (TEAM123456)',
+      );
     });
 
     testWithoutContext('returns null rather than falling back to a development cert', () {
@@ -110,10 +136,10 @@ void main() {
           _signer(fs: fileSystem, pm: pm, logger: logger).resolveIdentity();
       // codesign exits 0 with a revoked certificate, so picking it would
       // produce a build that only fails at submission.
-      expect(identity?.hash, 'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD');
+      expect(identity?.hash, 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC');
     });
 
-    testWithoutContext('returns null when the only Developer ID is revoked', () {
+    testWithoutContext('returns null when the only certificate is revoked', () {
       final pm = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: _findIdentity, stdout: _revokedOnly),
       ]);
@@ -327,7 +353,7 @@ void main() {
             '--options',
             'runtime',
             '--sign',
-            'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD',
+            'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
             '/artifacts/tvos_release_arm64/Flutter.xcframework/tvos-arm64/Flutter.framework',
           ],
           exitCode: 1,

--- a/test/general/tvos_engine_staging_test.dart
+++ b/test/general/tvos_engine_staging_test.dart
@@ -28,9 +28,10 @@ import '../src/context.dart';
 import '../src/fake_process_manager.dart';
 import '../src/fakes.dart';
 
-/// One Developer ID, so `resolveIdentity` has something to pick.
+/// One Apple Distribution certificate, so `resolveIdentity` has something to
+/// pick -- the certificate every developer who can upload to TestFlight holds.
 const String _identities = '''
-  1) DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD "Developer ID Application: Someone (TEAM123456)"
+  1) CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC "Apple Distribution: Someone (TEAM123456)"
      1 valid identity found
 ''';
 
@@ -115,7 +116,7 @@ void main() {
                 '--options',
                 'runtime',
                 '--sign',
-                'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD',
+                'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
                 RegExp(r'.*Flutter\.framework$'),
               ],
             ),


### PR DESCRIPTION
Targets `dev` per `CONTRIBUTING.md`.

**Version:** 1.9.0 → **1.10.0**, at the maintainer's request. Minor rather than patch — the API-key path is a new capability and is additive. For the record, `CONTRIBUTING.md` asks contributors to leave the version alone and file under `[Unreleased]`; this is that call being made deliberately, not the convention being missed.

> **Revised after review.** Two claims in the original description were wrong and have been removed rather than edited quietly: that only the key id is ever logged, and that the tests drove every branch. A third — a "58 pre-existing failures" baseline — was an artifact of running the suite without the resolved `TMPDIR` CI passes. Details in the thread.

## The problem

`-allowProvisioningUpdates` lets Xcode create or refresh a provisioning profile, but on its own it can only do so through a signed-in Xcode account. On a machine without a usable one — CI, or a developer who only has an API key — xcodebuild cannot fetch the profile and quietly settles for a cached **wildcard** one instead.

Any app with an entitlement then fails, and fails misleadingly:

```
error: Provisioning profile "tvOS Team Provisioning Profile: *"
doesn't include the Game Center capability.
```

That names the capability the *wildcard* lacks, not the credential that is actually missing. The obvious next step is to go auditing the App ID's capabilities in the developer portal — where everything is already correct.

## How it came up

An Apple TV device build of an app carrying `com.apple.developer.game-center` failed with exactly that. The App ID was `UNIVERSAL` and already had `GAME_CENTER` enabled; querying the App Store Connect API showed the real gap was that **no `TVOS_APP_DEVELOPMENT` profile existed for that bundle at all** — iOS, App Store, watch and Mac profiles were all present.

With the key forwarded, xcodebuild created the missing profile and the same build signed, installed and launched on the device unchanged.

## The change

Forward `-authenticationKeyPath` / `-authenticationKeyID` / `-authenticationKeyIssuerID` when the environment supplies all three:

```sh
export APP_STORE_CONNECT_KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_XXXX.p8
export APP_STORE_CONNECT_KEY_ID=XXXXXXXXXX
export APP_STORE_CONNECT_ISSUER_ID=<issuer-uuid>
```

**Additive.** Set none of them and nothing is added: a machine with a working Xcode account behaves exactly as before, silently.

**Anything between that and a working setup is reported.** xcodebuild requires all three or none, so a partial set is not forwarded — but it is not swallowed either. The gate tests *presence in the environment*, not a non-empty value, because an undefined CI secret interpolates to the empty string rather than to an absent variable: all three are set, the operator has demonstrably configured this, and treating it as unconfigured loses the only signal there is. The warning names the missing variable, including the `APP_STORE_CONNECT_KEY_ISSUER_ID` guess that the asymmetric naming invites. A key path that does not exist warns too, and says so when a literal `~` is the reason.

**Input handling.** Values are trimmed — `KEY_ID=$(cat keyid)` and most secret stores append a newline, and in a path the invisible `\n` renders a warning whose path looks perfectly correct. A leading `~` is expanded against `HOME`: an interactive shell expands it before the CLI sees it, but a CI `env:` block, a quoted assignment, a `.env` file and an Xcode scheme variable all deliver it literally. The path is made absolute, because `existsSync` resolves against the CLI's cwd while xcodebuild runs with `workingDirectory: tvosProjectDir.path`.

**Output.** A successful handover names the key id at default verbosity, so "working", "half-configured" and "never configured" can be told apart from the log. The `.p8` contents never pass through the CLI — only the path is read, and xcodebuild opens the file itself. The path, key id and issuer id are not secret and *do* appear in output: on that success line, and in xcodebuild's own echoed command line, which the caller dumps to `printError` on a failed build.

The args are resolved before `startProgress`, not inside the argument list, so a warning is not emitted at the top of a multi-minute build and then buried under xcodebuild's stdout and stderr — the same reasoning the migration guards below already follow.

## Tests

17 cases in `test/general/tvos_code_signing_test.dart` covering the forwarding path, each way the trio can be incomplete or empty, trimming, tilde expansion with and without `HOME`, relative-path resolution, the missing-file fallback, and the success log.

`resolveAuthenticationArgs` takes its environment, file system and logger as arguments, so those drive it directly. The call site needed extracting to be reachable at all: `NativeTvosBundle.xcodebuildArgs` now assembles the argv, following the existing `aotAssembleArgs` / `aotLinkArgs` pattern, and is tested for forwarding the signing and authentication args on a device build and neither on a simulator. Without it the feature could be unhooked from the build entirely with the suite still green.

Also drops the two cases in `Code signing - simulator vs device`, which asserted `expect(const <String>[], isEmpty)` and `expect(isSimulator, isFalse)` against local constants and could not fail. The new group makes both claims against production code.

**Suite is green**, run as CI runs it: `dev` (cc9caf5) 431 passing / 0 failing, this branch 446 / 0 — the +15 being the net change here. `dart analyze --fatal-infos lib/ test/ bin/` clean.

## Also included: two docs fixes

`README.md` documented none of the three variables — they appeared only in `CHANGELOG.md` and the dartdoc, so a user was guessing them from the xcodebuild flag names, and guessing wrong on the issuer. They are now in the Code signing section alongside the engine-signing ones.

`CONTRIBUTING.md`: the documented test command omitted the resolved `TMPDIR` that `.github/workflows/test.yml` passes and `test/README.md` explains, so anyone following it hits ~58 phantom failures from the FS guard's symlink mismatch — which is exactly how the bogus baseline above got into this description. Prefix added, and the stale "74 unit tests" corrected (there are ~450 across 40 files).

It also gains a note on a gotcha that cost me a build cycle: `shared.sh` only recompiles `bin/cache/flutter-tvos.snapshot` when `git rev-parse HEAD` changes, so an *uncommitted* edit under `lib/` silently runs the previously compiled snapshot — same build, same error, byte for byte, reading as a wrong fix rather than one that never executed. I first fixed this in `tool_revision` and then measured it, which argued against shipping it: detecting a dirty tree costs **~28 ms of `git status` on every invocation**, about 6% of a 493 ms startup, paid by every user of a public CLI to help only the few editing it. Happy to split either docs change out.